### PR TITLE
Add support for multiline string literals

### DIFF
--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -206,7 +206,7 @@ func (l *lexer) scanEscape(quote rune) rune {
 func (l *lexer) scanString(quote rune) (n int) {
 	ch := l.next() // read character after quote
 	for ch != quote {
-		if ch == '\n' || ch == eof {
+		if ch == eof || ch == '\n' && quote != '`' {
 			l.error("literal not terminated")
 			return
 		}

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -36,10 +36,11 @@ var lexTests = []lexTest{
 		},
 	},
 	{
-		`"double" 'single' "abc \n\t\"\\" '"\'' "'\"" "\xC3\xBF\u263A\U000003A8" '❤️'`,
+		`"double" 'single'` + "`multi\nline\n`" + `"abc \n\t\"\\" '"\'' "'\"" "\xC3\xBF\u263A\U000003A8" '❤️'`,
 		[]Token{
 			{Kind: String, Value: "double"},
 			{Kind: String, Value: "single"},
+			{Kind: String, Value: "multi\nline\n"},
 			{Kind: String, Value: "abc \n\t\"\\"},
 			{Kind: String, Value: "\"'"},
 			{Kind: String, Value: "'\""},

--- a/parser/lexer/state.go
+++ b/parser/lexer/state.go
@@ -14,7 +14,7 @@ func root(l *lexer) stateFn {
 	case IsSpace(r):
 		l.ignore()
 		return root
-	case r == '\'' || r == '"':
+	case r == '\'' || r == '"' || r == '`':
 		l.scanString(r)
 		str, err := unescape(l.word())
 		if err != nil {

--- a/parser/lexer/utils.go
+++ b/parser/lexer/utils.go
@@ -35,7 +35,7 @@ func unescape(value string) (string, error) {
 	}
 
 	// Quoted string of some form, must have same first and last char.
-	if value[0] != value[n-1] || (value[0] != '"' && value[0] != '\'') {
+	if value[0] != value[n-1] || (value[0] != '"' && value[0] != '\'' && value[0] != '`') {
 		return value, fmt.Errorf("unable to unescape string")
 	}
 
@@ -63,10 +63,10 @@ func unescape(value string) (string, error) {
 
 // unescapeChar takes a string input and returns the following info:
 //
-//   value - the escaped unicode rune at the front of the string.
-//   multibyte - whether the rune value might require multiple bytes to represent.
-//   tail - the remainder of the input string.
-//   err - error value, if the character could not be unescaped.
+//	value - the escaped unicode rune at the front of the string.
+//	multibyte - whether the rune value might require multiple bytes to represent.
+//	tail - the remainder of the input string.
+//	err - error value, if the character could not be unescaped.
 //
 // When multibyte is true the return value may still fit within a single byte,
 // but a multibyte conversion is attempted which is more expensive than when the

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -24,6 +24,10 @@ func TestParse(t *testing.T) {
 			&StringNode{Value: "str"},
 		},
 		{
+			"`multi\nline\nstring`",
+			&StringNode{Value: "multi\nline\nstring"},
+		},
+		{
 			"3",
 			&IntegerNode{Value: 3},
 		},


### PR DESCRIPTION
Currently, an env variable can hold a multiline string, for example:
```go
func main() {
	env := map[string]interface{}{
		"lines": `Here are
two lines`,
	}

	out, _ := expr.Eval("lines", env)
	fmt.Print(out)
}
```
Which prints out:
```
Here are
two lines
```
Whereas if I want to use a multiline string _literal_, then an error is returned.
```go
	out, err := expr.Eval("'Here are\ntwo lines'", env)
	if err != nil {
		panic(err)
	}
```
```
panic: literal not terminated (2:1)
 | two lines'
 | ^
```
A workaround is to use double backslashes:
```go
	out, err := expr.Eval("'Here are\\ntwo lines'", env)
```
Whilst this gives the desired output in this situation, it is impractical for our case.
Apart from the excessive line length, there are other issues like readability.

We have a requirement where the input strings do not exist in Go code, but are read from other sources (e.g. yaml files) and use the `map` function on a collection. An example would be something like this, but with many more lines and arguments:
```
map(things, sprintf(`
Thing Name: %s
Thing Size: %d`, 
.name, 
.size))
```
This PR adds support for multiline string literals through the backtick character, so it will handle our situation as well as more simple ones:
```go
	out, err := expr.Eval("`Here are\ntwo lines`", env)
```
