### PR TITLE
Enhance the number parser to include support for parsing hexadecimal, binary, and octal literals.

### DIFF
--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -18,7 +18,7 @@ func TestLex(t *testing.T) {
 		tokens []Token
 	}{
 		{
-			".5 0.025 1 02 1e3 0xFF 1.2e-4 1_000_000 _42 -.5",
+			".5 0.025 1 02 1e3 0xFF 0b0101 0o600 1.2e-4 1_000_000 _42 -.5",
 			[]Token{
 				{Kind: Number, Value: ".5"},
 				{Kind: Number, Value: "0.025"},
@@ -26,6 +26,8 @@ func TestLex(t *testing.T) {
 				{Kind: Number, Value: "02"},
 				{Kind: Number, Value: "1e3"},
 				{Kind: Number, Value: "0xFF"},
+				{Kind: Number, Value: "0b0101"},
+				{Kind: Number, Value: "0o600"},
 				{Kind: Number, Value: "1.2e-4"},
 				{Kind: Number, Value: "1_000_000"},
 				{Kind: Identifier, Value: "_42"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -307,7 +307,7 @@ func (p *parser) parseSecondary() Node {
 		p.next()
 		value := strings.Replace(token.Value, "_", "", -1)
 		isHex := strings.HasPrefix(value, "0x") || strings.HasPrefix(value, "0X")
-		if !isHex && strings.ContainsAny(value, ".eE") {
+		if !isHex && strings.ContainsAny(value, ".eE+-") {
 			number, err := strconv.ParseFloat(value, 64)
 			if err != nil {
 				p.error("invalid float literal: %v", err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -570,6 +570,46 @@ foo ?? bar || baz
 Operator (||) and coalesce expressions (??) cannot be mixed. Wrap either by parentheses. (1:12)
  | foo ?? bar || baz
  | ...........^
+
+0b15
+bad number syntax: "0b15" (1:5)
+ | 0b15
+ | ....^
+
+0X10G
+bad number syntax: "0X10G" (1:6)
+ | 0X10G
+ | .....^
+
+0o1E
+invalid float literal: strconv.ParseFloat: parsing "0o1E": invalid syntax (1:4)
+ | 0o1E
+ | ...^
+
+0b1E
+invalid float literal: strconv.ParseFloat: parsing "0b1E": invalid syntax (1:4)
+ | 0b1E
+ | ...^
+
+0b1E+6
+bad number syntax: "0b1E+6" (1:7)
+ | 0b1E+6
+ | ......^
+
+0b1E+1
+invalid float literal: strconv.ParseFloat: parsing "0b1E+1": invalid syntax (1:6)
+ | 0b1E+1
+ | .....^
+
+0o1E+1
+invalid float literal: strconv.ParseFloat: parsing "0o1E+1": invalid syntax (1:6)
+ | 0o1E+1
+ | .....^
+
+1E
+invalid float literal: strconv.ParseFloat: parsing "1E": invalid syntax (1:2)
+ | 1E
+ | .^
 `
 
 func TestParse_error(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/antonmedv/expr/ast"
-	"github.com/antonmedv/expr/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	. "github.com/antonmedv/expr/ast"
+	"github.com/antonmedv/expr/parser"
 )
 
 func TestParse(t *testing.T) {
@@ -35,6 +36,26 @@ func TestParse(t *testing.T) {
 		{
 			"0x6E",
 			&IntegerNode{Value: 110},
+		},
+		{
+			"0X63",
+			&IntegerNode{Value: 99},
+		},
+		{
+			"0o600",
+			&IntegerNode{Value: 384},
+		},
+		{
+			"0O45",
+			&IntegerNode{Value: 37},
+		},
+		{
+			"0b10",
+			&IntegerNode{Value: 2},
+		},
+		{
+			"0B101011",
+			&IntegerNode{Value: 43},
 		},
 		{
 			"10_000_000",


### PR DESCRIPTION
The current parser lacks support for the following numeric representations:

1. Octal literals.
2. Binary literals.
3. Hexadecimal literals with a '0X' prefix.