### PR TITLE
Fix: checker panic on embedded pointer to struct field

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -131,6 +131,7 @@ func TestCheck(t *testing.T) {
 		{"(Any.Bool ?? Bool) > 0"},
 		{"Bool ?? Bool"},
 		{"let foo = 1; foo == 1"},
+		{"(Embed).EmbedPointerEmbedInt > 0"},
 	}
 
 	for _, tt := range tests {

--- a/checker/types.go
+++ b/checker/types.go
@@ -192,7 +192,11 @@ func fetchField(t reflect.Type, name string) (reflect.StructField, bool) {
 		for i := 0; i < t.NumField(); i++ {
 			anon := t.Field(i)
 			if anon.Anonymous {
-				if field, ok := fetchField(anon.Type, name); ok {
+				anonType := anon.Type
+				for anonType.Kind() == reflect.Pointer {
+					anonType = anonType.Elem()
+				}
+				if field, ok := fetchField(anonType, name); ok {
 					field.Index = append(anon.Index, field.Index...)
 					return field, true
 				}

--- a/expr_test.go
+++ b/expr_test.go
@@ -2180,6 +2180,68 @@ func TestIssue462(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIssue_embedded_pointer_struct(t *testing.T) {
+	var tests = []struct {
+		input string
+		env   mock.Env
+		want  any
+	}{
+		{
+			input: "(Embed).EmbedPointerEmbedInt > 0",
+			env: mock.Env{
+				Embed: mock.Embed{
+					EmbedPointerEmbed: &mock.EmbedPointerEmbed{
+						EmbedPointerEmbedInt: 123,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			input: "(Embed).EmbedPointerEmbedInt > 0",
+			env: mock.Env{
+				Embed: mock.Embed{
+					EmbedPointerEmbed: &mock.EmbedPointerEmbed{
+						EmbedPointerEmbedInt: 0,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			input: "(Embed).EmbedPointerEmbedMethod(0)",
+			env: mock.Env{
+				Embed: mock.Embed{
+					EmbedPointerEmbed: &mock.EmbedPointerEmbed{
+						EmbedPointerEmbedInt: 0,
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			input: "(Embed).EmbedPointerEmbedPointerReceiverMethod(0)",
+			env: mock.Env{
+				Embed: mock.Embed{
+					EmbedPointerEmbed: nil,
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			program, err := expr.Compile(tt.input, expr.Env(tt.env))
+			require.NoError(t, err)
+
+			out, err := expr.Run(program, tt.env)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, out)
+		})
+	}
+}
+
 func TestIssue(t *testing.T) {
 	testCases := []struct {
 		code string

--- a/test/mock/mock.go
+++ b/test/mock/mock.go
@@ -103,11 +103,16 @@ func (Env) NotStringerStringerEqual(f fmt.Stringer, g fmt.Stringer) bool {
 
 type Embed struct {
 	EmbedEmbed
+	*EmbedPointerEmbed
 	EmbedString string
 }
 
 func (p Embed) EmbedMethod(_ int) string {
 	return ""
+}
+
+type EmbedPointerEmbed struct {
+	EmbedPointerEmbedInt int
 }
 
 type EmbedEmbed struct {

--- a/test/mock/mock.go
+++ b/test/mock/mock.go
@@ -115,6 +115,14 @@ type EmbedPointerEmbed struct {
 	EmbedPointerEmbedInt int
 }
 
+func (p EmbedPointerEmbed) EmbedPointerEmbedMethod(_ int) string {
+	return ""
+}
+
+func (p *EmbedPointerEmbed) EmbedPointerEmbedPointerReceiverMethod(_ int) string {
+	return ""
+}
+
 type EmbedEmbed struct {
 	EmbedEmbedString string
 }


### PR DESCRIPTION
Here's a fix for a case I ran into in practice - the checker panics on a valid input:

expression: 
```go
(Embed).EmbedPointerEmbedInt > 0
```
environment: 
```go
type Env struct {
	Embed
}
type Embed struct {
	*EmbedPointerEmbed
}

type EmbedPointerEmbed struct {
	EmbedPointerEmbedInt int
}
```

crash:
```
panic: reflect: NumField of non-struct type *mock.EmbedPointerEmbed [recovered]
        panic: reflect: NumField of non-struct type *mock.EmbedPointerEmbed
```

The fix in this PR is to dereference embedded fields until they stop being pointers (see diff in checker/types.go).