### PR TITLE
replace unnecessary loop introduced in #500 with an if stmt

### DIFF
--- a/checker/types.go
+++ b/checker/types.go
@@ -193,7 +193,7 @@ func fetchField(t reflect.Type, name string) (reflect.StructField, bool) {
 			anon := t.Field(i)
 			if anon.Anonymous {
 				anonType := anon.Type
-				for anonType.Kind() == reflect.Pointer {
+				if anonType.Kind() == reflect.Pointer {
 					anonType = anonType.Elem()
 				}
 				if field, ok := fetchField(anonType, name); ok {


### PR DESCRIPTION
The `for` loop from #500 is unnecessary. It doesn't break anything but it does cause an useless extra comparison after the first iteration if the loop is entered. This PR replaces it with an `if`.

I hadn't realized before that the embedded struct will never have a multi-level pointer type: you can't directly embed a `**struct` field and if the field is in a doubly-nested struct, that will take two recursion levels of `fetchField` to reach, with a `*struct` type each time. 