### PR TITLE
Fix operator overloading

### DIFF
--- a/conf/operators.go
+++ b/conf/operators.go
@@ -48,12 +48,13 @@ func (p *OperatorPatcher) Visit(node *ast.Node) {
 	leftType := binaryNode.Left.Type()
 	rightType := binaryNode.Right.Type()
 
-	_, fn, ok := FindSuitableOperatorOverload(fns, p.Types, leftType, rightType)
+	ret, fn, ok := FindSuitableOperatorOverload(fns, p.Types, leftType, rightType)
 	if ok {
 		newNode := &ast.CallNode{
 			Callee:    &ast.IdentifierNode{Value: fn},
 			Arguments: []ast.Node{binaryNode.Left, binaryNode.Right},
 		}
+		newNode.SetType(ret)
 		ast.Patch(node, newNode)
 	}
 }

--- a/expr_test.go
+++ b/expr_test.go
@@ -311,6 +311,47 @@ func ExampleOperator() {
 	// Output: true
 }
 
+func ExampleOperator_Decimal() {
+	type Decimal struct{ N float64 }
+	code := `A + B - C`
+
+	type Env struct {
+		A, B, C   Decimal
+		Sub       func(a, b Decimal) Decimal
+		Add       func(a, b Decimal) Decimal
+	}
+
+	options := []expr.Option{
+		expr.Env(Env{}),
+		expr.Operator("+", "Add"),
+		expr.Operator("-", "Sub"),
+	}
+
+	program, err := expr.Compile(code, options...)
+	if err != nil {
+		fmt.Printf("Compile error: %v", err)
+		return
+	}
+
+	env := Env{
+		A: Decimal{3},
+		B: Decimal{2},
+		C: Decimal{1},
+		Sub: func(a, b Decimal) Decimal { return Decimal{a.N - b.N} },
+		Add: func(a, b Decimal) Decimal { return Decimal{a.N + b.N}  },
+	}
+
+	output, err := expr.Run(program, env)
+	if err != nil {
+		fmt.Printf("%v", err)
+		return
+	}
+
+	fmt.Printf("%v", output)
+
+	// Output: {4}
+}
+
 func fib(n int) int {
 	if n <= 1 {
 		return n


### PR DESCRIPTION
Hi there,

Firstly, thank you for your work! 

Secondly, let me explain the context of the PR :) 

While trying to get decimals and `expr` I encountered the following issue. When an operation is overloaded and its result becomes the object of another overloaded operation, it causes a compilation error.

**Example:**

Given
```go
package main

import (
	"fmt"

	"github.com/expr-lang/expr"
	"github.com/shopspring/decimal"
)

func main() {
	code := `A + B - C`

	type Env struct {
		A, B, C   decimal.Decimal
		Sub       func(a, b decimal.Decimal) decimal.Decimal
		Add       func(a, b decimal.Decimal) decimal.Decimal
	}

	options := []expr.Option{
		expr.Env(Env{}),
		expr.Operator("+", "Add"),
		expr.Operator("-", "Sub"),
	}

	program, err := expr.Compile(code, options...)
	if err != nil {
		fmt.Printf("Compile error: %v", err)
		return
	}

	env := Env{
		A: decimal.NewFromInt(3),
		B: decimal.NewFromInt(2),
		C: decimal.NewFromInt(1),
		Sub: func(a, b decimal.Decimal) decimal.Decimal { return a.Sub(b) },
		Add: func(a, b decimal.Decimal) decimal.Decimal { return a.Add(b)  },
	}

	output, err := expr.Run(program, env)
	if err != nil {
		fmt.Printf("%v", err)
		return
	}

	fmt.Printf("%v", output)
}
```

Expected
```
// Output: 4
```

Actual
```
invalid operation: decimal.Decimal - decimal.Decimal (1:7)
 | A + B - C
 | ......^
```

The flow of the bug is the following:

```go
1. Compile("A + B - C") 
2. Expr is "A + B + C"
3. Visit("A + B") // replaces "A + B" -> Add(A, B)
4. Expr is "Add(A, B) + C"
5. Visit("Add(A, B) + C") // mismatch between types. `Add(A, B)` is nil while `C` is decimal.Decimal
```
