### PR TITLE
Compare `any` arrays

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -2482,3 +2482,29 @@ func TestRaceCondition_variables(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestArrayComparison(t *testing.T) {
+	tests := []struct {
+		env  any
+		code string
+	}{
+		{[]string{"A", "B"}, "foo == ['A', 'B']"},
+		{[]int{1, 2}, "foo == [1, 2]"},
+		{[]uint8{1, 2}, "foo == [1, 2]"},
+		{[]float64{1.1, 2.2}, "foo == [1.1, 2.2]"},
+		{[]any{"A", 1, 1.1, true}, "foo == ['A', 1, 1.1, true]"},
+		{[]string{"A", "B"}, "foo != [1, 2]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			env := map[string]any{"foo": tt.env}
+			program, err := expr.Compile(tt.code, expr.Env(env))
+			require.NoError(t, err)
+
+			out, err := expr.Run(program, env)
+			require.NoError(t, err)
+			require.Equal(t, true, out)
+		})
+	}
+}

--- a/vm/runtime/helpers/main.go
+++ b/vm/runtime/helpers/main.go
@@ -19,6 +19,7 @@ func main() {
 				"cases_with_duration": func(op string) string {
 					return cases(op, uints, ints, floats, []string{"time.Duration"})
 				},
+				"array_equal_cases": func() string { return arrayEqualCases([]string{"string"}, uints, ints, floats) },
 			}).
 			Parse(helpers),
 	).Execute(&b, nil)
@@ -89,6 +90,45 @@ func cases(op string, xs ...[]string) string {
 	return strings.TrimRight(out, "\n")
 }
 
+func arrayEqualCases(xs ...[]string) string {
+	var types []string
+	for _, x := range xs {
+		types = append(types, x...)
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "Generating array equal cases for %v\n", types)
+
+	var out string
+	echo := func(s string, xs ...any) {
+		out += fmt.Sprintf(s, xs...) + "\n"
+	}
+	echo(`case []any:`)
+	echo(`switch y := b.(type) {`)
+	for _, a := range append(types, "any") {
+		echo(`case []%v:`, a)
+		echo(`if len(x) != len(y) { return false }`)
+		echo(`for i := range x {`)
+		echo(`if !Equal(x[i], y[i]) { return false }`)
+		echo(`}`)
+		echo("return true")
+	}
+	echo(`}`)
+	for _, a := range types {
+		echo(`case []%v:`, a)
+		echo(`switch y := b.(type) {`)
+		echo(`case []any:`)
+		echo(`return Equal(y, x)`)
+		echo(`case []%v:`, a)
+		echo(`if len(x) != len(y) { return false }`)
+		echo(`for i := range x {`)
+		echo(`if x[i] != y[i] { return false }`)
+		echo(`}`)
+		echo("return true")
+		echo(`}`)
+	}
+	return strings.TrimRight(out, "\n")
+}
+
 func isFloat(t string) bool {
 	return strings.HasPrefix(t, "float")
 }
@@ -110,6 +150,7 @@ import (
 func Equal(a, b interface{}) bool {
 	switch x := a.(type) {
 	{{ cases "==" }}
+	{{ array_equal_cases }}
 	case string:
 		switch y := b.(type) {
 		case string:
@@ -123,6 +164,11 @@ func Equal(a, b interface{}) bool {
 	case time.Duration:
 		switch y := b.(type) {
 		case time.Duration:
+			return x == y
+		}
+	case bool:
+		switch y := b.(type) {
+		case bool:
 			return x == y
 		}
 	}

--- a/vm/runtime/helpers[generated].go
+++ b/vm/runtime/helpers[generated].go
@@ -334,6 +334,344 @@ func Equal(a, b interface{}) bool {
 		case float64:
 			return float64(x) == float64(y)
 		}
+	case []any:
+		switch y := b.(type) {
+		case []string:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []uint:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []uint8:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []uint16:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []uint32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []uint64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []int:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []int8:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []int16:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []int32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []int64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []float32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []float64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		case []any:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if !Equal(x[i], y[i]) {
+					return false
+				}
+			}
+			return true
+		}
+	case []string:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []string:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []uint:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []uint:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []uint8:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []uint8:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []uint16:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []uint16:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []uint32:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []uint32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []uint64:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []uint64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []int:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []int:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []int8:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []int8:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []int16:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []int16:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []int32:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []int32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []int64:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []int64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []float32:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []float32:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
+	case []float64:
+		switch y := b.(type) {
+		case []any:
+			return Equal(y, x)
+		case []float64:
+			if len(x) != len(y) {
+				return false
+			}
+			for i := range x {
+				if x[i] != y[i] {
+					return false
+				}
+			}
+			return true
+		}
 	case string:
 		switch y := b.(type) {
 		case string:
@@ -347,6 +685,11 @@ func Equal(a, b interface{}) bool {
 	case time.Duration:
 		switch y := b.(type) {
 		case time.Duration:
+			return x == y
+		}
+	case bool:
+		switch y := b.(type) {
+		case bool:
 			return x == y
 		}
 	}

--- a/vm/runtime/helpers_test.go
+++ b/vm/runtime/helpers_test.go
@@ -1,0 +1,57 @@
+package runtime_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr/vm/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+var tests = []struct {
+	name string
+	a, b any
+	want bool
+}{
+	{"int == int", 42, 42, true},
+	{"int != int", 42, 33, false},
+	{"int == int8", 42, int8(42), true},
+	{"int == int16", 42, int16(42), true},
+	{"int == int32", 42, int32(42), true},
+	{"int == int64", 42, int64(42), true},
+	{"float == float", 42.0, 42.0, true},
+	{"float != float", 42.0, 33.0, false},
+	{"float == int", 42.0, 42, true},
+	{"float != int", 42.0, 33, false},
+	{"string == string", "foo", "foo", true},
+	{"string != string", "foo", "bar", false},
+	{"bool == bool", true, true, true},
+	{"bool != bool", true, false, false},
+	{"[]any == []int", []any{1, 2, 3}, []int{1, 2, 3}, true},
+	{"[]any != []int", []any{1, 2, 3}, []int{1, 2, 99}, false},
+	{"deep []any == []any", []any{[]int{1}, 2, []any{"3"}}, []any{[]any{1}, 2, []string{"3"}}, true},
+	{"deep []any != []any", []any{[]int{1}, 2, []any{"3", "42"}}, []any{[]any{1}, 2, []string{"3"}}, false},
+	{"map[string]any == map[string]any", map[string]any{"a": 1}, map[string]any{"a": 1}, true},
+	{"map[string]any != map[string]any", map[string]any{"a": 1}, map[string]any{"a": 1, "b": 2}, false},
+}
+
+func TestEqual(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runtime.Equal(tt.a, tt.b)
+			assert.Equal(t, tt.want, got, "Equal(%v, %v) = %v; want %v", tt.a, tt.b, got, tt.want)
+			got = runtime.Equal(tt.b, tt.a)
+			assert.Equal(t, tt.want, got, "Equal(%v, %v) = %v; want %v", tt.b, tt.a, got, tt.want)
+		})
+	}
+
+}
+
+func BenchmarkEqual(b *testing.B) {
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				runtime.Equal(tt.a, tt.b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We can try to fix https://github.com/expr-lang/expr/issues/371 with nested comparison of arrays' values but I'm not sure if it's worth it to increase amount of switch-cases for such rare (imo) case.

Also, I found that expr always goes to `reflect.DeepEqual` for bools and fixed it.