### PR TITLE
`expr.Operator` passes before `expr.Env` caused error

### DIFF
--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -632,7 +632,7 @@ func TestCheck_TaggedFieldName(t *testing.T) {
 	tree, err := parser.Parse(`foo.bar`)
 	require.NoError(t, err)
 
-	config := &conf.Config{}
+	config := conf.CreateNew()
 	expr.Env(struct {
 		x struct {
 			y bool `expr:"bar"`

--- a/conf/config.go
+++ b/conf/config.go
@@ -32,6 +32,7 @@ type Config struct {
 func CreateNew() *Config {
 	c := &Config{
 		Optimize:  true,
+		Types:     make(TypesTable),
 		ConstFns:  make(map[string]reflect.Value),
 		Functions: make(map[string]*builtin.Function),
 		Builtins:  make(map[string]*builtin.Function),
@@ -62,7 +63,10 @@ func (c *Config) WithEnv(env any) {
 	}
 
 	c.Env = env
-	c.Types = CreateTypesTable(env)
+	types := CreateTypesTable(env)
+	for name, t := range types {
+		c.Types[name] = t
+	}
 	c.MapEnv = mapEnv
 	c.DefaultType = mapValueType
 	c.Strict = true

--- a/expr_test.go
+++ b/expr_test.go
@@ -2502,3 +2502,17 @@ func TestRaceCondition_variables(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestOperatorDependsOnEnv(t *testing.T) {
+	env := map[string]any{
+		"plus": func(a, b int) int {
+			return 42
+		},
+	}
+	program, err := expr.Compile(`1 + 2`, expr.Operator("+", "plus"), expr.Env(env))
+	require.NoError(t, err)
+
+	out, err := expr.Run(program, env)
+	require.NoError(t, err)
+	assert.Equal(t, 42, out)
+}


### PR DESCRIPTION
#605