### PR TITLE
Feature cahce print

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -27,6 +27,9 @@ func Patch(node *Node, newNode Node) {
 type base struct {
 	loc      file.Location
 	nodeType reflect.Type
+
+	// cache string result for reusing
+	strCache string
 }
 
 // Location returns the location of the node in the source code.

--- a/ast/node.go
+++ b/ast/node.go
@@ -30,6 +30,7 @@ type base struct {
 
 	// cache string result for reusing
 	strCache string
+	hasCache bool
 }
 
 // Location returns the location of the node in the source code.

--- a/ast/print.go
+++ b/ast/print.go
@@ -37,15 +37,20 @@ func (n *ConstantNode) String() string {
 	if n.Value == nil {
 		return "nil"
 	}
+	if n.hasCache {
+		return n.strCache
+	}
 	b, err := json.Marshal(n.Value)
 	if err != nil {
 		panic(err)
 	}
-	return string(b)
+	n.hasCache = true
+	n.strCache = string(b)
+	return n.strCache
 }
 
 func (n *UnaryNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	op := n.Operator
@@ -57,14 +62,16 @@ func (n *UnaryNode) String() string {
 	} else {
 		n.strCache = fmt.Sprintf("%s%s", op, n.Node.String())
 	}
+	n.hasCache = true
 	return n.strCache
 }
 
 func (n *BinaryNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	if n.Operator == ".." {
+		n.hasCache = true
 		n.strCache = fmt.Sprintf("%s..%s", n.Left, n.Right)
 		return n.strCache
 	}
@@ -107,6 +114,7 @@ func (n *BinaryNode) String() string {
 		rhs = n.Right.String()
 	}
 
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("%s %s %s", lhs, n.Operator, rhs)
 	return n.strCache
 }
@@ -116,7 +124,7 @@ func (n *ChainNode) String() string {
 }
 
 func (n *MemberNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	if n.Optional {
@@ -134,11 +142,12 @@ func (n *MemberNode) String() string {
 	} else {
 		n.strCache = fmt.Sprintf("%s[%s]", n.Node.String(), n.Property.String())
 	}
+	n.hasCache = true
 	return n.strCache
 }
 
 func (n *SliceNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	if n.From == nil && n.To == nil {
@@ -150,29 +159,32 @@ func (n *SliceNode) String() string {
 	} else {
 		n.strCache = fmt.Sprintf("%s[%s:%s]", n.Node.String(), n.From.String(), n.To.String())
 	}
+	n.hasCache = true
 	return n.strCache
 }
 
 func (n *CallNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
 	for i, arg := range n.Arguments {
 		arguments[i] = arg.String()
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("%s(%s)", n.Callee.String(), strings.Join(arguments, ", "))
 	return n.strCache
 }
 
 func (n *BuiltinNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
 	for i, arg := range n.Arguments {
 		arguments[i] = arg.String()
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("%s(%s)", n.Name, strings.Join(arguments, ", "))
 	return n.strCache
 }
@@ -186,15 +198,16 @@ func (n *PointerNode) String() string {
 }
 
 func (n *VariableDeclaratorNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("let %s = %s; %s", n.Name, n.Value.String(), n.Expr.String())
 	return n.strCache
 }
 
 func (n *ConditionalNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	var cond, exp1, exp2 string
@@ -213,36 +226,39 @@ func (n *ConditionalNode) String() string {
 	} else {
 		exp2 = n.Exp2.String()
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("%s ? %s : %s", cond, exp1, exp2)
 	return n.strCache
 }
 
 func (n *ArrayNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	nodes := make([]string, len(n.Nodes))
 	for i, node := range n.Nodes {
 		nodes[i] = node.String()
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("[%s]", strings.Join(nodes, ", "))
 	return n.strCache
 }
 
 func (n *MapNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	pairs := make([]string, len(n.Pairs))
 	for i, pair := range n.Pairs {
 		pairs[i] = pair.String()
 	}
+	n.hasCache = true
 	n.strCache = fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
 	return n.strCache
 }
 
 func (n *PairNode) String() string {
-	if n.strCache != "" {
+	if n.hasCache {
 		return n.strCache
 	}
 	if str, ok := n.Key.(*StringNode); ok {
@@ -254,5 +270,6 @@ func (n *PairNode) String() string {
 	} else {
 		n.strCache = fmt.Sprintf("(%s): %s", n.Key.String(), n.Value.String())
 	}
+	n.hasCache = true
 	return n.strCache
 }

--- a/ast/print.go
+++ b/ast/print.go
@@ -9,8 +9,6 @@ import (
 	"github.com/expr-lang/expr/parser/utils"
 )
 
-var EnableCache bool
-
 func (n *NilNode) String() string {
 	return "nil"
 }
@@ -47,7 +45,7 @@ func (n *ConstantNode) String() string {
 }
 
 func (n *UnaryNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	op := n.Operator
@@ -63,7 +61,7 @@ func (n *UnaryNode) String() string {
 }
 
 func (n *BinaryNode) String() string {
-	if EnableCache &&  n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	if n.Operator == ".." {
@@ -118,7 +116,7 @@ func (n *ChainNode) String() string {
 }
 
 func (n *MemberNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	if n.Optional {
@@ -140,7 +138,7 @@ func (n *MemberNode) String() string {
 }
 
 func (n *SliceNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	if n.From == nil && n.To == nil {
@@ -156,7 +154,7 @@ func (n *SliceNode) String() string {
 }
 
 func (n *CallNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
@@ -168,7 +166,7 @@ func (n *CallNode) String() string {
 }
 
 func (n *BuiltinNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
@@ -188,7 +186,7 @@ func (n *PointerNode) String() string {
 }
 
 func (n *VariableDeclaratorNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	n.strCache = fmt.Sprintf("let %s = %s; %s", n.Name, n.Value.String(), n.Expr.String())
@@ -196,7 +194,7 @@ func (n *VariableDeclaratorNode) String() string {
 }
 
 func (n *ConditionalNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	var cond, exp1, exp2 string
@@ -220,7 +218,7 @@ func (n *ConditionalNode) String() string {
 }
 
 func (n *ArrayNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	nodes := make([]string, len(n.Nodes))
@@ -232,7 +230,7 @@ func (n *ArrayNode) String() string {
 }
 
 func (n *MapNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	pairs := make([]string, len(n.Pairs))
@@ -244,7 +242,7 @@ func (n *MapNode) String() string {
 }
 
 func (n *PairNode) String() string {
-	if EnableCache && n.strCache != "" {
+	if n.strCache != "" {
 		return n.strCache
 	}
 	if str, ok := n.Key.(*StringNode); ok {

--- a/ast/print.go
+++ b/ast/print.go
@@ -9,6 +9,8 @@ import (
 	"github.com/expr-lang/expr/parser/utils"
 )
 
+var EnableCache bool
+
 func (n *NilNode) String() string {
 	return "nil"
 }
@@ -45,7 +47,7 @@ func (n *ConstantNode) String() string {
 }
 
 func (n *UnaryNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	op := n.Operator
@@ -61,7 +63,7 @@ func (n *UnaryNode) String() string {
 }
 
 func (n *BinaryNode) String() string {
-	if n.strCache != "" {
+	if EnableCache &&  n.strCache != "" {
 		return n.strCache
 	}
 	if n.Operator == ".." {
@@ -116,7 +118,7 @@ func (n *ChainNode) String() string {
 }
 
 func (n *MemberNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	if n.Optional {
@@ -138,7 +140,7 @@ func (n *MemberNode) String() string {
 }
 
 func (n *SliceNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	if n.From == nil && n.To == nil {
@@ -154,7 +156,7 @@ func (n *SliceNode) String() string {
 }
 
 func (n *CallNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
@@ -166,7 +168,7 @@ func (n *CallNode) String() string {
 }
 
 func (n *BuiltinNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	arguments := make([]string, len(n.Arguments))
@@ -186,7 +188,7 @@ func (n *PointerNode) String() string {
 }
 
 func (n *VariableDeclaratorNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	n.strCache = fmt.Sprintf("let %s = %s; %s", n.Name, n.Value.String(), n.Expr.String())
@@ -194,7 +196,7 @@ func (n *VariableDeclaratorNode) String() string {
 }
 
 func (n *ConditionalNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	var cond, exp1, exp2 string
@@ -218,7 +220,7 @@ func (n *ConditionalNode) String() string {
 }
 
 func (n *ArrayNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	nodes := make([]string, len(n.Nodes))
@@ -230,7 +232,7 @@ func (n *ArrayNode) String() string {
 }
 
 func (n *MapNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	pairs := make([]string, len(n.Pairs))
@@ -242,7 +244,7 @@ func (n *MapNode) String() string {
 }
 
 func (n *PairNode) String() string {
-	if n.strCache != "" {
+	if EnableCache && n.strCache != "" {
 		return n.strCache
 	}
 	if str, ok := n.Key.(*StringNode); ok {

--- a/ast/print_test.go
+++ b/ast/print_test.go
@@ -79,6 +79,7 @@ func TestPrint(t *testing.T) {
 			tree, err := parser.Parse(tt.input)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, tree.Node.String())
+			assert.Equal(t, tt.want, tree.Node.String())
 		})
 	}
 }
@@ -91,6 +92,7 @@ func TestPrint_MemberNode(t *testing.T) {
 		Property: &ast.StringNode{Value: "b c"},
 		Optional: true,
 	}
+	require.Equal(t, `a?.["b c"]`, node.String())
 	require.Equal(t, `a?.["b c"]`, node.String())
 }
 
@@ -114,6 +116,7 @@ func TestPrint_ConstantNode(t *testing.T) {
 			node := &ast.ConstantNode{
 				Value: tt.input,
 			}
+			require.Equal(t, tt.want, node.String())
 			require.Equal(t, tt.want, node.String())
 		})
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -395,34 +395,12 @@ func (c *compiler) UnaryNode(node *ast.UnaryNode) {
 }
 
 func (c *compiler) BinaryNode(node *ast.BinaryNode) {
-	l := kind(node.Left)
-	r := kind(node.Right)
-
-	leftIsSimple := isSimpleType(node.Left)
-	rightIsSimple := isSimpleType(node.Right)
-	leftAndRightAreSimple := leftIsSimple && rightIsSimple
-
 	switch node.Operator {
 	case "==":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-
-		if l == r && l == reflect.Int && leftAndRightAreSimple {
-			c.emit(OpEqualInt)
-		} else if l == r && l == reflect.String && leftAndRightAreSimple {
-			c.emit(OpEqualString)
-		} else {
-			c.emit(OpEqual)
-		}
+		c.equalBinaryNode(node)
 
 	case "!=":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-		c.emit(OpEqual)
+		c.equalBinaryNode(node)
 		c.emit(OpNot)
 
 	case "or", "||":
@@ -577,6 +555,28 @@ func (c *compiler) BinaryNode(node *ast.BinaryNode) {
 	default:
 		panic(fmt.Sprintf("unknown operator (%v)", node.Operator))
 
+	}
+}
+
+func (c *compiler) equalBinaryNode(node *ast.BinaryNode) {
+	l := kind(node.Left)
+	r := kind(node.Right)
+
+	leftIsSimple := isSimpleType(node.Left)
+	rightIsSimple := isSimpleType(node.Right)
+	leftAndRightAreSimple := leftIsSimple && rightIsSimple
+
+	c.compile(node.Left)
+	c.derefInNeeded(node.Left)
+	c.compile(node.Right)
+	c.derefInNeeded(node.Right)
+
+	if l == r && l == reflect.Int && leftAndRightAreSimple {
+		c.emit(OpEqualInt)
+	} else if l == r && l == reflect.String && leftAndRightAreSimple {
+		c.emit(OpEqualString)
+	} else {
+		c.emit(OpEqual)
 	}
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -597,7 +597,13 @@ func BenchmarkCompileWithProfile(b *testing.B) {
 			c.Profile = true
 		}
 	}
-	code := `let m = {"a": {"b": {"c": 1}}}; let n = {"x": {"y": 2}}; m?.a?.b?.c + n?.x?.y + testFunc(n?.x?.y, m?.a?.b?.c)`
+	code := `let m = {"a": {"b": {"c": 1}}}; 
+	let n = {"x": {"y": 2}}; 
+	m?.a?.b?.c + n?.x?.y + 
+	testFunc(n?.x?.y, m?.a?.b?.c) + 
+	testFunc(n?.x?.y, m?.a?.b?.c) + 
+	testFunc(n?.x?.y, m?.a?.b?.c)
+	`
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = expr.Compile(code,

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/expr-lang/expr"
-	"github.com/expr-lang/expr/ast"
 	"github.com/expr-lang/expr/conf"
 	"github.com/expr-lang/expr/test/mock"
 	"github.com/expr-lang/expr/test/playground"
@@ -598,29 +597,15 @@ func BenchmarkCompileWithProfile(b *testing.B) {
 			c.Profile = true
 		}
 	}
-
 	code := `let m = {"a": {"b": {"c": 1}}}; let n = {"x": {"y": 2}}; m?.a?.b?.c + n?.x?.y + testFunc(n?.x?.y, m?.a?.b?.c)`
-	ast.EnableCache = true
-	b.Run("enable print cache", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = expr.Compile(code,
-				withProfile(),
-				expr.Function("testFunc", func(...interface{}) (interface{}, error) {
-					return nil, nil
-				}),
-			)
-		}
-	})
-
-	ast.EnableCache = false
-	b.Run("disable print cache", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = expr.Compile(code,
-				withProfile(),
-				expr.Function("testFunc", func(...interface{}) (interface{}, error) {
-					return nil, nil
-				}),
-			)
-		}
-	})
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = expr.Compile(code,
+			withProfile(),
+			expr.Function("testFunc", func(...interface{}) (interface{}, error) {
+				return nil, nil
+			}),
+		)
+	}
+	b.StopTimer()
 }


### PR DESCRIPTION
Caching string result of node and make it can be reused. It's help for invoking `ast.Node.Sring()` multi times. For example. It's will help for run faster below code:
https://github.com/expr-lang/expr/blob/7772ea0fee5c9b153439a0ad5ee2e2b1a764f453/compiler/compiler.go#L206