### PR TITLE
Feature parenthesis node

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -214,3 +214,12 @@ type PairNode struct {
 	Key   Node // Key of the pair.
 	Value Node // Value of the pair.
 }
+
+// ParenthesisNode represents a node with parenthesis.
+// Example:
+//
+//	(foo and bar)
+type ParenthesisNode struct {
+	base
+	Value Node
+}

--- a/ast/print.go
+++ b/ast/print.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/expr-lang/expr/parser/operator"
 	"github.com/expr-lang/expr/parser/utils"
 )
 
@@ -45,11 +44,9 @@ func (n *ConstantNode) String() string {
 }
 
 func (n *UnaryNode) String() string {
-	op := ""
+	op := n.Operator
 	if n.Operator == "not" {
 		op = fmt.Sprintf("%s ", n.Operator)
-	} else {
-		op = fmt.Sprintf("%s", n.Operator)
 	}
 	if _, ok := n.Node.(*BinaryNode); ok {
 		return fmt.Sprintf("%s(%s)", op, n.Node.String())
@@ -63,42 +60,8 @@ func (n *BinaryNode) String() string {
 	}
 
 	var lhs, rhs string
-	var lwrap, rwrap bool
-
-	lb, ok := n.Left.(*BinaryNode)
-	if ok {
-		if operator.Less(lb.Operator, n.Operator) {
-			lwrap = true
-		}
-		if lb.Operator == "??" {
-			lwrap = true
-		}
-		if operator.IsBoolean(lb.Operator) && n.Operator != lb.Operator {
-			lwrap = true
-		}
-	}
-
-	rb, ok := n.Right.(*BinaryNode)
-	if ok {
-		if operator.Less(rb.Operator, n.Operator) {
-			rwrap = true
-		}
-		if operator.IsBoolean(rb.Operator) && n.Operator != rb.Operator {
-			rwrap = true
-		}
-	}
-
-	if lwrap {
-		lhs = fmt.Sprintf("(%s)", n.Left.String())
-	} else {
-		lhs = n.Left.String()
-	}
-
-	if rwrap {
-		rhs = fmt.Sprintf("(%s)", n.Right.String())
-	} else {
-		rhs = n.Right.String()
-	}
+	lhs = n.Left.String()
+	rhs = n.Right.String()
 
 	return fmt.Sprintf("%s %s %s", lhs, n.Operator, rhs)
 }
@@ -167,21 +130,9 @@ func (n *VariableDeclaratorNode) String() string {
 
 func (n *ConditionalNode) String() string {
 	var cond, exp1, exp2 string
-	if _, ok := n.Cond.(*ConditionalNode); ok {
-		cond = fmt.Sprintf("(%s)", n.Cond.String())
-	} else {
-		cond = n.Cond.String()
-	}
-	if _, ok := n.Exp1.(*ConditionalNode); ok {
-		exp1 = fmt.Sprintf("(%s)", n.Exp1.String())
-	} else {
-		exp1 = n.Exp1.String()
-	}
-	if _, ok := n.Exp2.(*ConditionalNode); ok {
-		exp2 = fmt.Sprintf("(%s)", n.Exp2.String())
-	} else {
-		exp2 = n.Exp2.String()
-	}
+	cond = n.Cond.String()
+	exp1 = n.Exp1.String()
+	exp2 = n.Exp2.String()
 	return fmt.Sprintf("%s ? %s : %s", cond, exp1, exp2)
 }
 
@@ -208,5 +159,9 @@ func (n *PairNode) String() string {
 		}
 		return fmt.Sprintf("%q: %s", str.String(), n.Value.String())
 	}
-	return fmt.Sprintf("(%s): %s", n.Key.String(), n.Value.String())
+	return fmt.Sprintf("%s: %s", n.Key.String(), n.Value.String())
+}
+
+func (n *ParenthesisNode) String() string {
+	return fmt.Sprintf("(%s)", n.Value)
 }

--- a/ast/print_test.go
+++ b/ast/print_test.go
@@ -44,11 +44,11 @@ func TestPrint(t *testing.T) {
 		{`a not in b`, `not (a in b)`},
 		{`a and b`, `a and b`},
 		{`a or b`, `a or b`},
-		{`a or b and c`, `a or (b and c)`},
+		{`a or b and c`, `a or b and c`},
 		{`a or (b and c)`, `a or (b and c)`},
 		{`(a or b) and c`, `(a or b) and c`},
 		{`a ? b : c`, `a ? b : c`},
-		{`a ? b : c ? d : e`, `a ? b : (c ? d : e)`},
+		{`a ? b : c ? d : e`, `a ? b : c ? d : e`},
 		{`(a ? b : c) ? d : e`, `(a ? b : c) ? d : e`},
 		{`a ? (b ? c : d) : e`, `a ? (b ? c : d) : e`},
 		{`func()`, `func()`},
@@ -72,6 +72,7 @@ func TestPrint(t *testing.T) {
 		{`a[:]`, `a[:]`},
 		{`(nil ?? 1) > 0`, `(nil ?? 1) > 0`},
 		{`{("a" + "b"): 42}`, `{("a" + "b"): 42}`},
+		{`(UserID != 0 ? true : false) && ProductID == 1`, `(UserID != 0 ? true : false) && ProductID == 1`},
 	}
 
 	for _, tt := range tests {

--- a/ast/visitor.go
+++ b/ast/visitor.go
@@ -63,6 +63,8 @@ func Walk(node *Node, v Visitor) {
 	case *PairNode:
 		Walk(&n.Key, v)
 		Walk(&n.Value, v)
+	case *ParenthesisNode:
+		Walk(&n.Value, v)	
 	default:
 		panic(fmt.Sprintf("undefined node type (%T)", node))
 	}

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -126,6 +126,8 @@ func (v *checker) visit(node ast.Node) (reflect.Type, info) {
 		t, i = v.MapNode(n)
 	case *ast.PairNode:
 		t, i = v.PairNode(n)
+	case *ast.ParenthesisNode:
+		t, i = v.visit(n.Value)
 	default:
 		panic(fmt.Sprintf("undefined node type (%T)", node))
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -395,34 +395,12 @@ func (c *compiler) UnaryNode(node *ast.UnaryNode) {
 }
 
 func (c *compiler) BinaryNode(node *ast.BinaryNode) {
-	l := kind(node.Left)
-	r := kind(node.Right)
-
-	leftIsSimple := isSimpleType(node.Left)
-	rightIsSimple := isSimpleType(node.Right)
-	leftAndRightAreSimple := leftIsSimple && rightIsSimple
-
 	switch node.Operator {
 	case "==":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-
-		if l == r && l == reflect.Int && leftAndRightAreSimple {
-			c.emit(OpEqualInt)
-		} else if l == r && l == reflect.String && leftAndRightAreSimple {
-			c.emit(OpEqualString)
-		} else {
-			c.emit(OpEqual)
-		}
+		c.equalBinaryNode(node)
 
 	case "!=":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-		c.emit(OpEqual)
+		c.equalBinaryNode(node)
 		c.emit(OpNot)
 
 	case "or", "||":
@@ -577,6 +555,28 @@ func (c *compiler) BinaryNode(node *ast.BinaryNode) {
 	default:
 		panic(fmt.Sprintf("unknown operator (%v)", node.Operator))
 
+	}
+}
+
+func (c *compiler) equalBinaryNode(node *ast.BinaryNode) {
+	l := kind(node.Left)
+	r := kind(node.Right)
+
+	leftIsSimple := isSimpleType(node.Left)
+	rightIsSimple := isSimpleType(node.Right)
+	leftAndRightAreSimple := leftIsSimple && rightIsSimple
+
+	c.compile(node.Left)
+	c.derefInNeeded(node.Left)
+	c.compile(node.Right)
+	c.derefInNeeded(node.Right)
+
+	if l == r && l == reflect.Int && leftAndRightAreSimple {
+		c.emit(OpEqualInt)
+	} else if l == r && l == reflect.String && leftAndRightAreSimple {
+		c.emit(OpEqualString)
+	} else {
+		c.emit(OpEqual)
 	}
 }
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -265,6 +265,8 @@ func (c *compiler) compile(node ast.Node) {
 		c.MapNode(n)
 	case *ast.PairNode:
 		c.PairNode(n)
+	case *ast.ParenthesisNode:
+		c.compile(n.Value)
 	default:
 		panic(fmt.Sprintf("undefined node type (%T)", node))
 	}

--- a/optimizer/fold.go
+++ b/optimizer/fold.go
@@ -321,6 +321,17 @@ func (fold *fold) Visit(node *Node) {
 				})
 			}
 		}
+	case *ParenthesisNode:
+		switch val := n.Value.(type) {
+		case *IntegerNode,
+			*StringNode,
+			*FloatNode,
+			*BoolNode,
+			*ConstantNode,
+			*IdentifierNode,
+			*ParenthesisNode:
+			patch(val)
+		}
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -276,7 +276,10 @@ func (p *parser) parsePrimary() Node {
 		p.next()
 		expr := p.parseExpression(0)
 		p.expect(Bracket, ")") // "an opened parenthesis is not properly closed"
-		return p.parsePostfixExpression(expr)
+		pExpr := &ParenthesisNode{
+			Value: expr,
+		}
+		return p.parsePostfixExpression(pExpr)
 	}
 
 	if p.depth > 0 {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -112,10 +112,12 @@ world`},
 			"(1 - 2) * 3",
 			&BinaryNode{
 				Operator: "*",
-				Left: &BinaryNode{
-					Operator: "-",
-					Left:     &IntegerNode{Value: 1},
-					Right:    &IntegerNode{Value: 2},
+				Left: &ParenthesisNode{
+					Value: &BinaryNode{
+						Operator: "-",
+						Left:     &IntegerNode{Value: 1},
+						Right:    &IntegerNode{Value: 2},
+					},
 				},
 				Right: &IntegerNode{Value: 3},
 			},
@@ -139,9 +141,12 @@ world`},
 		{
 			"(a or b) and c",
 			&BinaryNode{Operator: "and",
-				Left: &BinaryNode{Operator: "or",
-					Left:  &IdentifierNode{Value: "a"},
-					Right: &IdentifierNode{Value: "b"}},
+				Left: &ParenthesisNode{
+					Value: &BinaryNode{Operator: "or",
+						Left:  &IdentifierNode{Value: "a"},
+						Right: &IdentifierNode{Value: "b"},
+					},
+				},
 				Right: &IdentifierNode{Value: "c"}},
 		},
 		{
@@ -509,9 +514,14 @@ world`},
 			"foo ?? (bar || baz)",
 			&BinaryNode{Operator: "??",
 				Left: &IdentifierNode{Value: "foo"},
-				Right: &BinaryNode{Operator: "||",
-					Left:  &IdentifierNode{Value: "bar"},
-					Right: &IdentifierNode{Value: "baz"}}},
+				Right: &ParenthesisNode{
+					Value: &BinaryNode{
+						Operator: "||",
+						Left:     &IdentifierNode{Value: "bar"},
+						Right:    &IdentifierNode{Value: "baz"},
+					},
+				},
+			},
 		},
 		{
 			"foo || bar ?? baz",


### PR DESCRIPTION
I found there are many operator of adding parentheses in ast/print.go
for example:
https://github.com/expr-lang/expr/blob/7772ea0fee5c9b153439a0ad5ee2e2b1a764f453/ast/print.go#L54-L56
https://github.com/expr-lang/expr/blob/7772ea0fee5c9b153439a0ad5ee2e2b1a764f453/ast/print.go#L91-L101
why not add a specific type ast node for following benefits:
1、make printing string more like the expr inputted by user, i.e. resolve issue: https://github.com/expr-lang/expr/issues/613.
2、Make the node's responsibilities more single.

