### PR TITLE
Feature parenthesis prop

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -13,6 +13,7 @@ type Node interface {
 	Type() reflect.Type
 	SetType(reflect.Type)
 	String() string
+	SetParenthesis()
 }
 
 // Patch replaces the node with a new one.
@@ -27,6 +28,8 @@ func Patch(node *Node, newNode Node) {
 type base struct {
 	loc      file.Location
 	nodeType reflect.Type
+
+	hasParen bool
 }
 
 // Location returns the location of the node in the source code.
@@ -47,6 +50,15 @@ func (n *base) Type() reflect.Type {
 // SetType sets the type of the node.
 func (n *base) SetType(t reflect.Type) {
 	n.nodeType = t
+}
+
+// SetParenthesis indicate node is surround by bracket
+func (n *base) SetParenthesis() {
+	n.hasParen = true
+}
+
+func (n *base) parenthesis() bool {
+	return n.hasParen
 }
 
 // NilNode represents nil.

--- a/ast/print.go
+++ b/ast/print.go
@@ -5,208 +5,251 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/expr-lang/expr/parser/operator"
 	"github.com/expr-lang/expr/parser/utils"
 )
 
 func (n *NilNode) String() string {
-	return "nil"
+	res := "nil"
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *IdentifierNode) String() string {
-	return n.Value
+	res := n.Value
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *IntegerNode) String() string {
-	return fmt.Sprintf("%d", n.Value)
+	res := fmt.Sprintf("%d", n.Value)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *FloatNode) String() string {
-	return fmt.Sprintf("%v", n.Value)
+	res := fmt.Sprintf("%v", n.Value)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *BoolNode) String() string {
-	return fmt.Sprintf("%t", n.Value)
+	res := fmt.Sprintf("%t", n.Value)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *StringNode) String() string {
-	return fmt.Sprintf("%q", n.Value)
+	res := fmt.Sprintf("%q", n.Value)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *ConstantNode) String() string {
-	if n.Value == nil {
-		return "nil"
+	res := func() string {
+		if n.Value == nil {
+			return "nil"
+		}
+		b, err := json.Marshal(n.Value)
+		if err != nil {
+			panic(err)
+		}
+		return string(b)
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	b, err := json.Marshal(n.Value)
-	if err != nil {
-		panic(err)
-	}
-	return string(b)
+	return res
 }
 
 func (n *UnaryNode) String() string {
-	op := ""
-	if n.Operator == "not" {
-		op = fmt.Sprintf("%s ", n.Operator)
-	} else {
-		op = fmt.Sprintf("%s", n.Operator)
+	res := func() string {
+		op := n.Operator
+		if n.Operator == "not" {
+			op = fmt.Sprintf("%s ", n.Operator)
+		}
+		return fmt.Sprintf("%s%s", op, n.Node.String())
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	if _, ok := n.Node.(*BinaryNode); ok {
-		return fmt.Sprintf("%s(%s)", op, n.Node.String())
-	}
-	return fmt.Sprintf("%s%s", op, n.Node.String())
+	return res
 }
 
 func (n *BinaryNode) String() string {
-	if n.Operator == ".." {
-		return fmt.Sprintf("%s..%s", n.Left, n.Right)
-	}
-
-	var lhs, rhs string
-	var lwrap, rwrap bool
-
-	lb, ok := n.Left.(*BinaryNode)
-	if ok {
-		if operator.Less(lb.Operator, n.Operator) {
-			lwrap = true
+	res := func() string {
+		if n.Operator == ".." {
+			return fmt.Sprintf("%s..%s", n.Left, n.Right)
 		}
-		if lb.Operator == "??" {
-			lwrap = true
-		}
-		if operator.IsBoolean(lb.Operator) && n.Operator != lb.Operator {
-			lwrap = true
-		}
+		return fmt.Sprintf("%s %s %s", n.Left, n.Operator, n.Right)
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-
-	rb, ok := n.Right.(*BinaryNode)
-	if ok {
-		if operator.Less(rb.Operator, n.Operator) {
-			rwrap = true
-		}
-		if operator.IsBoolean(rb.Operator) && n.Operator != rb.Operator {
-			rwrap = true
-		}
-	}
-
-	if lwrap {
-		lhs = fmt.Sprintf("(%s)", n.Left.String())
-	} else {
-		lhs = n.Left.String()
-	}
-
-	if rwrap {
-		rhs = fmt.Sprintf("(%s)", n.Right.String())
-	} else {
-		rhs = n.Right.String()
-	}
-
-	return fmt.Sprintf("%s %s %s", lhs, n.Operator, rhs)
+	return res
 }
 
 func (n *ChainNode) String() string {
-	return n.Node.String()
+	res := n.Node.String()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *MemberNode) String() string {
-	if n.Optional {
+	res := func() string {
+		if n.Optional {
+			if str, ok := n.Property.(*StringNode); ok && utils.IsValidIdentifier(str.Value) {
+				return fmt.Sprintf("%s?.%s", n.Node.String(), str.Value)
+			} else {
+				return fmt.Sprintf("%s?.[%s]", n.Node.String(), n.Property.String())
+			}
+		}
 		if str, ok := n.Property.(*StringNode); ok && utils.IsValidIdentifier(str.Value) {
-			return fmt.Sprintf("%s?.%s", n.Node.String(), str.Value)
-		} else {
-			return fmt.Sprintf("%s?.[%s]", n.Node.String(), n.Property.String())
+			if _, ok := n.Node.(*PointerNode); ok {
+				return fmt.Sprintf(".%s", str.Value)
+			}
+			return fmt.Sprintf("%s.%s", n.Node.String(), str.Value)
 		}
+		return fmt.Sprintf("%s[%s]", n.Node.String(), n.Property.String())
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	if str, ok := n.Property.(*StringNode); ok && utils.IsValidIdentifier(str.Value) {
-		if _, ok := n.Node.(*PointerNode); ok {
-			return fmt.Sprintf(".%s", str.Value)
-		}
-		return fmt.Sprintf("%s.%s", n.Node.String(), str.Value)
-	}
-	return fmt.Sprintf("%s[%s]", n.Node.String(), n.Property.String())
+	return res
 }
 
 func (n *SliceNode) String() string {
-	if n.From == nil && n.To == nil {
-		return fmt.Sprintf("%s[:]", n.Node.String())
+	res := func() string {
+		if n.From == nil && n.To == nil {
+			return fmt.Sprintf("%s[:]", n.Node.String())
+		}
+		if n.From == nil {
+			return fmt.Sprintf("%s[:%s]", n.Node.String(), n.To.String())
+		}
+		if n.To == nil {
+			return fmt.Sprintf("%s[%s:]", n.Node.String(), n.From.String())
+		}
+		return fmt.Sprintf("%s[%s:%s]", n.Node.String(), n.From.String(), n.To.String())
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	if n.From == nil {
-		return fmt.Sprintf("%s[:%s]", n.Node.String(), n.To.String())
-	}
-	if n.To == nil {
-		return fmt.Sprintf("%s[%s:]", n.Node.String(), n.From.String())
-	}
-	return fmt.Sprintf("%s[%s:%s]", n.Node.String(), n.From.String(), n.To.String())
+	return res
 }
 
 func (n *CallNode) String() string {
-	arguments := make([]string, len(n.Arguments))
-	for i, arg := range n.Arguments {
-		arguments[i] = arg.String()
+	res := func() string {
+		arguments := make([]string, len(n.Arguments))
+		for i, arg := range n.Arguments {
+			arguments[i] = arg.String()
+		}
+		return fmt.Sprintf("%s(%s)", n.Callee.String(), strings.Join(arguments, ", "))
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	return fmt.Sprintf("%s(%s)", n.Callee.String(), strings.Join(arguments, ", "))
+	return res
 }
 
 func (n *BuiltinNode) String() string {
-	arguments := make([]string, len(n.Arguments))
-	for i, arg := range n.Arguments {
-		arguments[i] = arg.String()
+	res := func() string {
+		arguments := make([]string, len(n.Arguments))
+		for i, arg := range n.Arguments {
+			arguments[i] = arg.String()
+		}
+		return fmt.Sprintf("%s(%s)", n.Name, strings.Join(arguments, ", "))
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	return fmt.Sprintf("%s(%s)", n.Name, strings.Join(arguments, ", "))
+	return res
 }
 
 func (n *ClosureNode) String() string {
-	return n.Node.String()
+	res := n.Node.String()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *PointerNode) String() string {
-	return fmt.Sprintf("#%s", n.Name)
+	res := fmt.Sprintf("#%s", n.Name)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *VariableDeclaratorNode) String() string {
-	return fmt.Sprintf("let %s = %s; %s", n.Name, n.Value.String(), n.Expr.String())
+	res := fmt.Sprintf("let %s = %s; %s", n.Name, n.Value.String(), n.Expr.String())
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
+	}
+	return res
 }
 
 func (n *ConditionalNode) String() string {
-	var cond, exp1, exp2 string
-	if _, ok := n.Cond.(*ConditionalNode); ok {
-		cond = fmt.Sprintf("(%s)", n.Cond.String())
-	} else {
-		cond = n.Cond.String()
+	res := fmt.Sprintf("%s ? %s : %s", n.Cond, n.Exp1, n.Exp2)
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	if _, ok := n.Exp1.(*ConditionalNode); ok {
-		exp1 = fmt.Sprintf("(%s)", n.Exp1.String())
-	} else {
-		exp1 = n.Exp1.String()
-	}
-	if _, ok := n.Exp2.(*ConditionalNode); ok {
-		exp2 = fmt.Sprintf("(%s)", n.Exp2.String())
-	} else {
-		exp2 = n.Exp2.String()
-	}
-	return fmt.Sprintf("%s ? %s : %s", cond, exp1, exp2)
+	return res
 }
 
 func (n *ArrayNode) String() string {
-	nodes := make([]string, len(n.Nodes))
-	for i, node := range n.Nodes {
-		nodes[i] = node.String()
+	res := func() string {
+		nodes := make([]string, len(n.Nodes))
+		for i, node := range n.Nodes {
+			nodes[i] = node.String()
+		}
+		return fmt.Sprintf("[%s]", strings.Join(nodes, ", "))
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	return fmt.Sprintf("[%s]", strings.Join(nodes, ", "))
+	return res
 }
 
 func (n *MapNode) String() string {
-	pairs := make([]string, len(n.Pairs))
-	for i, pair := range n.Pairs {
-		pairs[i] = pair.String()
+	res := func() string {
+		pairs := make([]string, len(n.Pairs))
+		for i, pair := range n.Pairs {
+			pairs[i] = pair.String()
+		}
+		return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	return fmt.Sprintf("{%s}", strings.Join(pairs, ", "))
+	return res
 }
 
 func (n *PairNode) String() string {
-	if str, ok := n.Key.(*StringNode); ok {
-		if utils.IsValidIdentifier(str.Value) {
-			return fmt.Sprintf("%s: %s", str.Value, n.Value.String())
+	res := func() string {
+		if str, ok := n.Key.(*StringNode); ok {
+			if utils.IsValidIdentifier(str.Value) {
+				return fmt.Sprintf("%s: %s", str.Value, n.Value.String())
+			}
+			return fmt.Sprintf("%q: %s", str.String(), n.Value.String())
 		}
-		return fmt.Sprintf("%q: %s", str.String(), n.Value.String())
+		return fmt.Sprintf("%s: %s", n.Key, n.Value)
+	}()
+	if n.parenthesis() {
+		res = fmt.Sprintf("(%s)", res)
 	}
-	return fmt.Sprintf("(%s): %s", n.Key.String(), n.Value.String())
+	return res
 }

--- a/ast/print_test.go
+++ b/ast/print_test.go
@@ -44,11 +44,11 @@ func TestPrint(t *testing.T) {
 		{`a not in b`, `not (a in b)`},
 		{`a and b`, `a and b`},
 		{`a or b`, `a or b`},
-		{`a or b and c`, `a or (b and c)`},
+		{`a or b and c`, `a or b and c`},
 		{`a or (b and c)`, `a or (b and c)`},
 		{`(a or b) and c`, `(a or b) and c`},
 		{`a ? b : c`, `a ? b : c`},
-		{`a ? b : c ? d : e`, `a ? b : (c ? d : e)`},
+		{`a ? b : c ? d : e`, `a ? b : c ? d : e`},
 		{`(a ? b : c) ? d : e`, `(a ? b : c) ? d : e`},
 		{`a ? (b ? c : d) : e`, `a ? (b ? c : d) : e`},
 		{`func()`, `func()`},
@@ -72,6 +72,7 @@ func TestPrint(t *testing.T) {
 		{`a[:]`, `a[:]`},
 		{`(nil ?? 1) > 0`, `(nil ?? 1) > 0`},
 		{`{("a" + "b"): 42}`, `{("a" + "b"): 42}`},
+		{`(UserID != 0 ? true : false) && ProductID == 1`, `(UserID != 0 ? true : false) && ProductID == 1`},
 	}
 
 	for _, tt := range tests {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -395,34 +395,12 @@ func (c *compiler) UnaryNode(node *ast.UnaryNode) {
 }
 
 func (c *compiler) BinaryNode(node *ast.BinaryNode) {
-	l := kind(node.Left)
-	r := kind(node.Right)
-
-	leftIsSimple := isSimpleType(node.Left)
-	rightIsSimple := isSimpleType(node.Right)
-	leftAndRightAreSimple := leftIsSimple && rightIsSimple
-
 	switch node.Operator {
 	case "==":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-
-		if l == r && l == reflect.Int && leftAndRightAreSimple {
-			c.emit(OpEqualInt)
-		} else if l == r && l == reflect.String && leftAndRightAreSimple {
-			c.emit(OpEqualString)
-		} else {
-			c.emit(OpEqual)
-		}
+		c.equalBinaryNode(node)
 
 	case "!=":
-		c.compile(node.Left)
-		c.derefInNeeded(node.Left)
-		c.compile(node.Right)
-		c.derefInNeeded(node.Right)
-		c.emit(OpEqual)
+		c.equalBinaryNode(node)
 		c.emit(OpNot)
 
 	case "or", "||":
@@ -577,6 +555,28 @@ func (c *compiler) BinaryNode(node *ast.BinaryNode) {
 	default:
 		panic(fmt.Sprintf("unknown operator (%v)", node.Operator))
 
+	}
+}
+
+func (c *compiler) equalBinaryNode(node *ast.BinaryNode) {
+	l := kind(node.Left)
+	r := kind(node.Right)
+
+	leftIsSimple := isSimpleType(node.Left)
+	rightIsSimple := isSimpleType(node.Right)
+	leftAndRightAreSimple := leftIsSimple && rightIsSimple
+
+	c.compile(node.Left)
+	c.derefInNeeded(node.Left)
+	c.compile(node.Right)
+	c.derefInNeeded(node.Right)
+
+	if l == r && l == reflect.Int && leftAndRightAreSimple {
+		c.emit(OpEqualInt)
+	} else if l == r && l == reflect.String && leftAndRightAreSimple {
+		c.emit(OpEqualString)
+	} else {
+		c.emit(OpEqual)
 	}
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -277,7 +277,9 @@ func (p *parser) parsePrimary() Node {
 		p.next()
 		expr := p.parseExpression(0)
 		p.expect(Bracket, ")") // "an opened parenthesis is not properly closed"
-		expr.SetParenthesis()
+		if expr != nil { // expr may be wrong, like not properly closed
+			expr.SetParenthesis()
+		}
 		return p.parsePostfixExpression(expr)
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -192,6 +192,7 @@ func (p *parser) parseExpression(precedence int) Node {
 			nodeLeft.SetLocation(opToken.Location)
 
 			if negate {
+				nodeLeft.SetParenthesis()
 				nodeLeft = &UnaryNode{
 					Operator: "not",
 					Node:     nodeLeft,
@@ -276,6 +277,7 @@ func (p *parser) parsePrimary() Node {
 		p.next()
 		expr := p.parseExpression(0)
 		p.expect(Bracket, ")") // "an opened parenthesis is not properly closed"
+		expr.SetParenthesis()
 		return p.parsePostfixExpression(expr)
 	}
 


### PR DESCRIPTION
Add `hasParen` field for ast.Ndoe, which indicated add parenthesis when invoking `String()`. 
I've always thought that you should keep the parenthetical information of the node if the user input it. 
 