### PR TITLE
Preserve The Specified Timezone In Parse

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -502,6 +502,7 @@ var Builtins = []*Function{
 				if err != nil {
 					return nil, err
 				}
+				t = t.In(tz)
 				return t, nil
 			}
 

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -113,6 +113,7 @@ func TestBuiltin(t *testing.T) {
 		{`duration("1h")`, time.Hour},
 		{`date("2006-01-02T15:04:05Z")`, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)},
 		{`date("2006.01.02", "2006.01.02")`, time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC)},
+		{`date("2023-04-23T00:30:00.000+0100", "2006-01-02T15:04:05-0700", "America/Chicago").Format("2006-01-02")`, "2023-04-22"},
 		{`first(ArrayOfString)`, "foo"},
 		{`first(ArrayOfInt)`, 1},
 		{`first(ArrayOfAny)`, 1},

--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -114,6 +114,8 @@ func TestBuiltin(t *testing.T) {
 		{`date("2006-01-02T15:04:05Z")`, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)},
 		{`date("2006.01.02", "2006.01.02")`, time.Date(2006, 1, 2, 0, 0, 0, 0, time.UTC)},
 		{`date("2023-04-23T00:30:00.000+0100", "2006-01-02T15:04:05-0700", "America/Chicago").Format("2006-01-02")`, "2023-04-22"},
+		{`date("2023-04-23T00:30:00", "2006-01-02T15:04:05", "America/Chicago").Format("2006-01-02")`, "2023-04-23"},
+		{`date("2023-04-23", "2006-01-02", "America/Chicago").Format("2006-01-02")`, "2023-04-23"},
 		{`first(ArrayOfString)`, "foo"},
 		{`first(ArrayOfInt)`, 1},
 		{`first(ArrayOfAny)`, 1},


### PR DESCRIPTION
When parsing a string into a Time using the optional timezone parameter, set the location of the Time to the timezone's location so that Format uses that timezone.