### PR TITLE
Fix tracking of applied operator patches per walk

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -22,7 +22,7 @@ func ParseCheck(input string, config *conf.Config) (*parser.Tree, error) {
 	}
 
 	if len(config.Visitors) > 0 {
-		for i := 0; i < 1000; i++ {
+		for {
 			more := false
 			for _, v := range config.Visitors {
 				// We need to perform types check, because some visitors may rely on

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -29,14 +29,22 @@ func ParseCheck(input string, config *conf.Config) (*parser.Tree, error) {
 				// types information available in the tree.
 				_, _ = Check(tree, config)
 
+				r, repeatable := v.(interface {
+					Reset()
+					ShouldRepeat() bool
+				});
+
+				if repeatable {
+					r.Reset()
+				}
+
 				ast.Walk(&tree.Node, v)
 
-				if v, ok := v.(interface {
-					ShouldRepeat() bool
-				}); ok {
-					more = more || v.ShouldRepeat()
+				if repeatable {
+					more = more || r.ShouldRepeat()
 				}
 			}
+
 			if !more {
 				break
 			}

--- a/patcher/operator_override.go
+++ b/patcher/operator_override.go
@@ -42,6 +42,11 @@ func (p *OperatorOverloading) Visit(node *ast.Node) {
 	}
 }
 
+// Tracking must be reset before every walk over the AST tree
+func (p *OperatorOverloading) Reset() {
+	p.applied = false
+}
+
 func (p *OperatorOverloading) ShouldRepeat() bool {
 	return p.applied
 }


### PR DESCRIPTION
Tracking if an operator overload patch was applied was not happening per-walk of the ast tree. This lead to re-running patchers a thousand times if any operator overload applied.

I added a `Reset()` method to the operator patcher that can be called before every walk to reset the tracking state.

I don't think the outer loop limit of 1000 is required anymore since state is being properly tracked. I can revert this patch and re-push if you want to keep the limit.

This is part of the problem for issue #637 