### PR TITLE
Separate patching phases for patchers that require multiple passes.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -22,7 +22,7 @@ func ParseCheck(input string, config *conf.Config) (*parser.Tree, error) {
 	}
 
 	if len(config.Visitors) > 0 {
-		for i := 0; i < 1000; i++ {
+		for {
 			more := false
 			for _, v := range config.Visitors {
 				// We need to perform types check, because some visitors may rely on

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -29,14 +29,22 @@ func ParseCheck(input string, config *conf.Config) (*parser.Tree, error) {
 				// types information available in the tree.
 				_, _ = Check(tree, config)
 
+				r, repeatable := v.(interface {
+					Reset()
+					ShouldRepeat() bool
+				});
+
+				if repeatable {
+					r.Reset()
+				}
+
 				ast.Walk(&tree.Node, v)
 
-				if v, ok := v.(interface {
-					ShouldRepeat() bool
-				}); ok {
-					more = more || v.ShouldRepeat()
+				if repeatable {
+					more = more || r.ShouldRepeat()
 				}
 			}
+
 			if !more {
 				break
 			}

--- a/patcher/operator_override.go
+++ b/patcher/operator_override.go
@@ -43,6 +43,11 @@ func (p *OperatorOverloading) Visit(node *ast.Node) {
 	}
 }
 
+// Tracking must be reset before every walk over the AST tree
+func (p *OperatorOverloading) Reset() {
+	p.applied = false
+}
+
 func (p *OperatorOverloading) ShouldRepeat() bool {
 	return p.applied
 }

--- a/test/patch/patch_count_test.go
+++ b/test/patch/patch_count_test.go
@@ -1,0 +1,61 @@
+package patch_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr/internal/testify/require"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/ast"
+	"github.com/expr-lang/expr/test/mock"
+)
+
+// This patcher tracks how many nodes it patches which can 
+// be used to verify if it was run too many times or not at all
+type countingPatcher struct {
+	PatchCount int
+}
+
+func (c *countingPatcher) Visit(node *ast.Node) {
+	switch (*node).(type) {
+	case *ast.IntegerNode:
+		c.PatchCount++
+	}
+}
+
+// Test over a simple expression
+func TestPatch_Count(t *testing.T) {
+	patcher := countingPatcher{}
+
+	_, err := expr.Compile(
+		`5 + 5`,
+		expr.Env(mock.Env{}),
+		expr.Patch(&patcher),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, patcher.PatchCount, "Patcher run an unexpected number of times during compile")
+}
+
+// Test with operator overloading
+func TestPatchOperator_Count(t *testing.T) {
+	patcher := countingPatcher{}
+
+	_, err := expr.Compile(
+		`5 + 5`,
+		expr.Env(mock.Env{}),
+		expr.Patch(&patcher),
+		expr.Operator("+", "_intAdd"),
+		expr.Function(
+			"_intAdd",
+			func(params ...any) (any, error) {
+				return params[0].(int) + params[1].(int), nil
+			},
+			new(func(int, int) int),
+		),
+	)
+
+	require.NoError(t, err)
+
+	require.Equal(t, 2, patcher.PatchCount, "Patcher run an unexpected number of times during compile")
+}


### PR DESCRIPTION
See issue #637

This contains the changes from pull request #658 as well. If this pull is accepted that one may be closed.

Commit https://github.com/expr-lang/expr/commit/3da85278439a5e8ef5dc0d73f321f76742e2cecc introduced repeating the patch phase for operator overloading, but also reruns all patchers any time an operator overload is patched.

This can break patchers that don't expect to be re-run over the statement multiple times. 

This patch set splits patching into two phases. First phase only patchers that don't require multiple passes are run. Second phase only patchers that require multiple passes are run.

As a side effect, it also allows any ordering between other patchers and operator overloads, where as previously if a patcher changed a nodes type it would have to be supplied as an option before the operator.

Passes all tests.

```
ok      github.com/expr-lang/expr       0.138s
ok      github.com/expr-lang/expr/ast   (cached)
ok      github.com/expr-lang/expr/builtin       0.015s
ok      github.com/expr-lang/expr/checker       0.013s
?       github.com/expr-lang/expr/conf  [no test files]
ok      github.com/expr-lang/expr/compiler      0.007s
ok      github.com/expr-lang/expr/docgen        (cached)
ok      github.com/expr-lang/expr/file  (cached)
ok      github.com/expr-lang/expr/internal/deref        (cached)
ok      github.com/expr-lang/expr/internal/difflib      (cached)
ok      github.com/expr-lang/expr/internal/spew (cached)
ok      github.com/expr-lang/expr/internal/testify/assert       (cached)
ok      github.com/expr-lang/expr/internal/testify/assert/internal/unsafetests  (cached)
ok      github.com/expr-lang/expr/internal/testify/require      (cached)
?       github.com/expr-lang/expr/parser/operator       [no test files]
?       github.com/expr-lang/expr/parser/utils  [no test files]
ok      github.com/expr-lang/expr/optimizer     0.009s
ok      github.com/expr-lang/expr/parser        (cached)
ok      github.com/expr-lang/expr/parser/lexer  (cached)
ok      github.com/expr-lang/expr/patcher       0.004s
ok      github.com/expr-lang/expr/patcher/value 0.004s
ok      github.com/expr-lang/expr/test/coredns  0.004s
ok      github.com/expr-lang/expr/test/crowdsec 0.052s
ok      github.com/expr-lang/expr/test/deref    0.005s
?       github.com/expr-lang/expr/test/mock     [no test files]
?       github.com/expr-lang/expr/test/playground       [no test files]
?       github.com/expr-lang/expr/vm/func_types [no test files]
?       github.com/expr-lang/expr/vm/runtime/helpers    [no test files]
ok      github.com/expr-lang/expr/test/fuzz     0.540s
ok      github.com/expr-lang/expr/test/gen      0.619s
ok      github.com/expr-lang/expr/test/interface_method 0.003s
ok      github.com/expr-lang/expr/test/operator 0.005s
ok      github.com/expr-lang/expr/test/operator/issues584       0.004s
ok      github.com/expr-lang/expr/test/patch    0.004s
ok      github.com/expr-lang/expr/test/patch/set_type   0.004s
ok      github.com/expr-lang/expr/test/pipes    0.004s
ok      github.com/expr-lang/expr/test/time     0.003s
ok      github.com/expr-lang/expr/vm    0.016s
ok      github.com/expr-lang/expr/vm/runtime    (cached)
```