### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ func main() {
 * [Visually.io](https://visually.io) employs Expr as a business rule engine for its personalization targeting algorithm.
 * [Akvorado](https://github.com/akvorado/akvorado) utilizes Expr to classify exporters and interfaces in network flows.
 * [keda.sh](https://keda.sh) uses Expr to allow customization of its Kubernetes-based event-driven autoscaling.
-* [Span Digital](https://spandigital.com/) uses Expr in it's Knowledge Management products.
+* [Span Digital](https://spandigital.com/) uses Expr in its Knowledge Management products.
 * [Xiaohongshu](https://www.xiaohongshu.com/) combining yaml with Expr for dynamically policies delivery.
 * [Melrōse](https://melrōse.org) uses Expr to implement its music programming language.
 * [Tork](https://www.tork.run/) integrates Expr into its workflow execution.
-* [Critical Moments](https://criticalmoments.io) uses Expr for it's mobile realtime conditional targeting system.
+* [Critical Moments](https://criticalmoments.io) uses Expr for its mobile realtime conditional targeting system.
 * [WoodpeckerCI](https://woodpecker-ci.org) uses Expr for [filtering workflows/steps](https://woodpecker-ci.org/docs/usage/workflow-syntax#evaluate).
 * [FastSchema](https://github.com/fastschema/fastschema) - A BaaS leveraging Expr for its customizable and dynamic Access Control system.
 

--- a/docs/language-definition.md
+++ b/docs/language-definition.md
@@ -691,7 +691,7 @@ concat([1, 2], [3, 4]) == [1, 2, 3, 4]
 
 ### flatten(array) {#flatten}
 
-Flattens given array into one-dimentional array.
+Flattens given array into one-dimensional array.
 
 ```expr
 flatten([1, 2, [3, 4]]) == [1, 2, 3, 4]

--- a/internal/spew/common.go
+++ b/internal/spew/common.go
@@ -78,7 +78,7 @@ func catchPanic(w io.Writer, v reflect.Value) {
 }
 
 // handleMethods attempts to call the Error and String methods on the underlying
-// type the passed reflect.Value represents and outputes the result to Writer w.
+// type the passed reflect.Value represents and outputs the result to Writer w.
 //
 // It handles panics in any called methods by catching and displaying the error
 // as the formatted value.
@@ -100,7 +100,7 @@ func handleMethods(cs *ConfigState, w io.Writer, v reflect.Value) (handled bool)
 	// Choose whether or not to do error and Stringer interface lookups against
 	// the base type or a pointer to the base type depending on settings.
 	// Technically calling one of these methods with a pointer receiver can
-	// mutate the value, however, types which choose to satisify an error or
+	// mutate the value, however, types which choose to satisfy an error or
 	// Stringer interface with a pointer receiver should not be mutating their
 	// state inside these interface methods.
 	if !cs.DisablePointerMethods && !UnsafeDisabled && !v.CanAddr() {

--- a/internal/spew/common_test.go
+++ b/internal/spew/common_test.go
@@ -154,7 +154,7 @@ func helpTestSortValues(tests []sortTestCase, cs *spew.ConfigState, t *testing.T
 	}
 }
 
-// TestSortValues ensures the sort functionality for relect.Value based sorting
+// TestSortValues ensures the sort functionality for reflect.Value based sorting
 // works as intended.
 func TestSortValues(t *testing.T) {
 	v := reflect.ValueOf
@@ -228,7 +228,7 @@ func TestSortValues(t *testing.T) {
 	helpTestSortValues(tests, &cs, t)
 }
 
-// TestSortValuesWithMethods ensures the sort functionality for relect.Value
+// TestSortValuesWithMethods ensures the sort functionality for reflect.Value
 // based sorting works as intended when using string methods.
 func TestSortValuesWithMethods(t *testing.T) {
 	v := reflect.ValueOf
@@ -263,7 +263,7 @@ func TestSortValuesWithMethods(t *testing.T) {
 	helpTestSortValues(tests, &cs, t)
 }
 
-// TestSortValuesWithSpew ensures the sort functionality for relect.Value
+// TestSortValuesWithSpew ensures the sort functionality for reflect.Value
 // based sorting works as intended when using spew to stringify keys.
 func TestSortValuesWithSpew(t *testing.T) {
 	v := reflect.ValueOf

--- a/internal/spew/config.go
+++ b/internal/spew/config.go
@@ -59,7 +59,7 @@ type ConfigState struct {
 	//
 	// NOTE: This might be an unsafe action since calling one of these methods
 	// with a pointer receiver could technically mutate the value, however,
-	// in practice, types which choose to satisify an error or Stringer
+	// in practice, types which choose to satisfy an error or Stringer
 	// interface with a pointer receiver should not be mutating their state
 	// inside these interface methods.  As a result, this option relies on
 	// access to the unsafe package, so it will not have any effect when
@@ -228,7 +228,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), and %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/internal/spew/doc.go
+++ b/internal/spew/doc.go
@@ -169,7 +169,7 @@ standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/internal/spew/dumpcgo_test.go
+++ b/internal/spew/dumpcgo_test.go
@@ -15,7 +15,7 @@
 // NOTE: Due to the following build constraints, this file will only be compiled
 // when both cgo is supported and "-tags testcgo" is added to the go test
 // command line.  This means the cgo tests are only added (and hence run) when
-// specifially requested.  This configuration is used because spew itself
+// specifically requested.  This configuration is used because spew itself
 // does not require cgo to run even though it does handle certain cgo types
 // specially.  Rather than forcing all clients to require cgo and an external
 // C compiler just to run the tests, this scheme makes them optional.
@@ -90,7 +90,7 @@ func addCgoDumpTests() {
 	addDumpTest(v5, "("+v5t+") "+v5s+"\n", "("+v5t2+") "+v5s+"\n")
 
 	// C typedefed unsigned char array.
-	v6, v6l, v6c := testdata.GetCgoTypdefedUnsignedCharArray()
+	v6, v6l, v6c := testdata.GetCgoTypedefedUnsignedCharArray()
 	v6Len := fmt.Sprintf("%d", v6l)
 	v6Cap := fmt.Sprintf("%d", v6c)
 	v6t := "[6]testdata._Ctype_custom_uchar_t"

--- a/internal/spew/format.go
+++ b/internal/spew/format.go
@@ -121,7 +121,7 @@ func (f *formatState) formatPtr(v reflect.Value) {
 	// Keep list of all dereferenced pointers to possibly show later.
 	pointerChain := make([]uintptr, 0)
 
-	// Figure out how many levels of indirection there are by derferencing
+	// Figure out how many levels of indirection there are by dereferencing
 	// pointers and unpacking interfaces down the chain while detecting circular
 	// references.
 	nilFound := false
@@ -405,7 +405,7 @@ types similar to the standard %v format specifier.
 
 The custom formatter only responds to the %v (most compact), %+v (adds pointer
 addresses), %#v (adds types), or %#+v (adds types and pointer addresses) verb
-combinations.  Any other verbs such as %x and %q will be sent to the the
+combinations.  Any other verbs such as %x and %q will be sent to the
 standard fmt package for formatting.  In addition, the custom formatter ignores
 the width and precision arguments (however they will still work on the format
 specifiers not handled by the custom formatter).

--- a/internal/spew/internal_test.go
+++ b/internal/spew/internal_test.go
@@ -15,7 +15,7 @@
  */
 
 /*
-This test file is part of the spew package rather than than the spew_test
+This test file is part of the spew package rather than the spew_test
 package because it needs access to internals to properly test certain cases
 which are not possible via the public interface since they should never happen.
 */

--- a/internal/spew/internalunsafe_test.go
+++ b/internal/spew/internalunsafe_test.go
@@ -20,7 +20,7 @@
 // +build !js,!appengine,!safe,!disableunsafe,go1.4
 
 /*
-This test file is part of the spew package rather than than the spew_test
+This test file is part of the spew package rather than the spew_test
 package because it needs access to internals to properly test certain cases
 which are not possible via the public interface since they should never happen.
 */

--- a/internal/spew/testdata/dumpcgo.go
+++ b/internal/spew/testdata/dumpcgo.go
@@ -76,8 +76,8 @@ func GetCgoUint8tArray() (interface{}, int, int) {
 	return C.ui8ta, len(C.ui8ta), cap(C.ui8ta)
 }
 
-// GetCgoTypdefedUnsignedCharArray returns a typedefed unsigned char array via
+// GetCgoTypedefedUnsignedCharArray returns a typedefed unsigned char array via
 // cgo and the array's len and cap.  This is only used for tests.
-func GetCgoTypdefedUnsignedCharArray() (interface{}, int, int) {
+func GetCgoTypedefedUnsignedCharArray() (interface{}, int, int) {
 	return C.tuca, len(C.tuca), cap(C.tuca)
 }

--- a/test/deref/deref_test.go
+++ b/test/deref/deref_test.go
@@ -204,7 +204,7 @@ func TestDeref_nil_in_pointer_of_interface(t *testing.T) {
 	})
 }
 
-func TestDeref_сommutative(t *testing.T) {
+func TestDeref_commutative(t *testing.T) {
 	a := "ok"
 	b := "ok"
 


### PR DESCRIPTION
Fixed a couple of typos, mostly in the `internal/spew` module which I'm guessing has been copied from the abandoned [davecgh/go-spew](https://github.com/davecgh/go-spew) project.