### PR TITLE
ci: add Go 1.23/1.24 testing and fix example test names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-versions: [ '1.18', '1.22' ]
+        go-versions: [ '1.18', '1.22', '1.24' ]
         go-arch: [ '386' ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-versions: [ '1.18', '1.19', '1.20', '1.21', '1.22' ]
+        go-versions: [ '1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24' ]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}

--- a/expr_test.go
+++ b/expr_test.go
@@ -312,7 +312,7 @@ func ExampleOperator() {
 	// Output: true
 }
 
-func ExampleOperator_Decimal() {
+func ExampleOperator_with_decimal() {
 	type Decimal struct{ N float64 }
 	code := `A + B - C`
 
@@ -585,7 +585,7 @@ func ExampleWithContext() {
 	// Output: 42
 }
 
-func ExampleWithTimezone() {
+func ExampleTimezone() {
 	program, err := expr.Compile(`now().Location().String()`, expr.Timezone("Asia/Kamchatka"))
 	if err != nil {
 		fmt.Printf("%v", err)

--- a/internal/difflib/difflib_test.go
+++ b/internal/difflib/difflib_test.go
@@ -102,7 +102,7 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffCode() {
+func ExampleGetUnifiedDiffString() {
 	a := `one
 two
 three
@@ -135,7 +135,7 @@ four`
 	// -fmt.Printf("%s,%T",a,b)
 }
 
-func ExampleGetContextDiffCode() {
+func ExampleGetContextDiffString() {
 	a := `one
 two
 three
@@ -172,7 +172,7 @@ four`
 	//   four
 }
 
-func ExampleGetContextDiffString() {
+func ExampleGetContextDiffString_second() {
 	a := `one
 two
 three


### PR DESCRIPTION
Expand test coverage to newer Go versions and fix compatibility issues:

- Add Go 1.23 and 1.24 to test matrix in test.yml
- Add Go 1.24 to build matrix in build.yml
- Fix example test names to match Go conventions:
  * ExampleOperator_Decimal → ExampleOperator_with_decimal
  * ExampleWithTimezone → ExampleTimezone
  * ExampleGetUnifiedDiffCode → ExampleGetUnifiedDiffString
  * ExampleGetContextDiffCode → ExampleGetContextDiffString
  * ExampleGetContextDiffString → ExampleGetContextDiffString_second

These changes maintain compatibility with Go 1.18 (as specified in go.mod) while ensuring the codebase works correctly with the latest Go versions, which enforce stricter naming conventions for example tests.

Needs #761 + rebase