### PR TITLE
ci: pin benchstat version and update GitHub Actions

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           go-version: 1.18
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        # NOTE: benchstat@latest requires go 1.23 since 2025-02-14 - this is the last go 1.18 ref
+        # https://cs.opensource.google/go/x/perf/+/c95ad7d5b636f67d322a7e4832e83103d0fdd292
+        run: go install golang.org/x/perf/cmd/benchstat@884df5810d2850d775c2cb4885a7ea339128a17d
 
       - uses: actions/checkout@v3
       - name: Benchmark new code

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,14 +21,14 @@ jobs:
           fuzz-seconds: 600
           output-sarif: true
       - name: Upload Crash
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts
           path: ./out/artifacts
       - name: Upload Sarif
         if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: cifuzz-sarif/results.sarif


### PR DESCRIPTION
At the moment CI runs fail due to:

- https://github.com/expr-lang/expr/actions/runs/13608368368/job/38042534081?pr=760
- https://github.com/expr-lang/expr/actions/runs/13608368368/job/38042534081?pr=760

This PR fixes CI workflow compatibility issues and updates dependencies:

- Pin benchstat to specific commit (884df5) compatible with Go 1.18
  instead of using "latest" which now requires Go 1.23+
- Add explanatory comment about benchstat version constraints
- Upgrade actions/upload-artifact from v3 to v4 in fuzz.yml
- Upgrade github/codeql-action from v2 to v3 in fuzz.yml

These changes ensure the CI pipeline remains compatible with Go 1.18
while benefiting from the latest improvements in GitHub Actions.

Hopefully fixes CI issues for #760