### PR TITLE
Reduce lexer memory allocs

### DIFF
--- a/file/error.go
+++ b/file/error.go
@@ -3,7 +3,6 @@ package file
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 )
 
 type Error struct {
@@ -19,43 +18,49 @@ func (e *Error) Error() string {
 	return e.format()
 }
 
+var tabReplacer = strings.NewReplacer("\t", " ")
+
 func (e *Error) Bind(source Source) *Error {
+	src := source.String()
+
 	e.Line = 1
-	for i, r := range source {
-		if i == e.From {
+	var runeCount, lineStart, lineOffset int
+	for i, r := range src {
+		if runeCount == e.From {
 			break
 		}
 		if r == '\n' {
+			lineStart = i
 			e.Line++
 			e.Column = 0
+			lineOffset = 0
 		} else {
 			e.Column++
 		}
+		runeCount++
+		lineOffset++
 	}
-	if snippet, found := source.Snippet(e.Line); found {
-		snippet := strings.Replace(snippet, "\t", " ", -1)
-		srcLine := "\n | " + snippet
-		var bytes = []byte(snippet)
-		var indLine = "\n | "
-		for i := 0; i < e.Column && len(bytes) > 0; i++ {
-			_, sz := utf8.DecodeRune(bytes)
-			bytes = bytes[sz:]
-			if sz > 1 {
-				goto noind
-			} else {
-				indLine += "."
-			}
-		}
-		if _, sz := utf8.DecodeRune(bytes); sz > 1 {
-			goto noind
-		} else {
-			indLine += "^"
-		}
-		srcLine += indLine
 
-	noind:
-		e.Snippet = srcLine
+	lineEnd := lineStart + strings.IndexByte(src[lineStart:], '\n')
+	if lineEnd < lineStart {
+		lineEnd = len(src)
 	}
+	if lineStart == lineEnd {
+		return e
+	}
+
+	const prefix = "\n | "
+	line := src[lineStart:lineEnd]
+	snippet := new(strings.Builder)
+	snippet.Grow(2*len(prefix) + len(line) + lineOffset + 1)
+	snippet.WriteString(prefix)
+	tabReplacer.WriteString(snippet, line)
+	snippet.WriteString(prefix)
+	for i := 0; i < lineOffset; i++ {
+		snippet.WriteByte('.')
+	}
+	snippet.WriteByte('^')
+	e.Snippet = snippet.String()
 	return e
 }
 

--- a/file/source.go
+++ b/file/source.go
@@ -1,48 +1,36 @@
 package file
 
-import (
-	"strings"
-	"unicode/utf8"
-)
+import "strings"
 
-type Source []rune
+type Source struct {
+	raw string
+}
 
 func NewSource(contents string) Source {
-	return []rune(contents)
+	return Source{
+		raw: contents,
+	}
 }
 
 func (s Source) String() string {
-	return string(s)
+	return s.raw
 }
 
 func (s Source) Snippet(line int) (string, bool) {
-	if s == nil {
+	if s.raw == "" {
 		return "", false
 	}
-	lines := strings.Split(string(s), "\n")
-	lineOffsets := make([]int, len(lines))
-	var offset int
-	for i, line := range lines {
-		offset = offset + utf8.RuneCountInString(line) + 1
-		lineOffsets[i] = offset
+	var start int
+	for i := 1; i < line; i++ {
+		pos := strings.IndexByte(s.raw[start:], '\n')
+		if pos < 0 {
+			return "", false
+		}
+		start += pos + 1
 	}
-	charStart, found := getLineOffset(lineOffsets, line)
-	if !found || len(s) == 0 {
-		return "", false
+	end := start + strings.IndexByte(s.raw[start:], '\n')
+	if end < start {
+		end = len(s.raw)
 	}
-	charEnd, found := getLineOffset(lineOffsets, line+1)
-	if found {
-		return string(s[charStart : charEnd-1]), true
-	}
-	return string(s[charStart:]), true
-}
-
-func getLineOffset(lineOffsets []int, line int) (int, bool) {
-	if line == 1 {
-		return 0, true
-	} else if line > 1 && line <= len(lineOffsets) {
-		offset := lineOffsets[line-2]
-		return offset, true
-	}
-	return -1, false
+	return s.raw[start:end], true
 }

--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -9,7 +9,7 @@ import (
 
 func Lex(source file.Source) ([]Token, error) {
 	l := &lexer{
-		source: source,
+		source: []rune(source.String()),
 		tokens: make([]Token, 0),
 		start:  0,
 		end:    0,
@@ -28,7 +28,7 @@ func Lex(source file.Source) ([]Token, error) {
 }
 
 type lexer struct {
-	source     file.Source
+	source     []rune
 	tokens     []Token
 	start, end int
 	err        *file.Error

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -335,6 +335,7 @@ literal not terminated (1:10)
 früh ♥︎
 unrecognized character: U+2665 '♥' (1:6)
  | früh ♥︎
+ | .....^
 `
 
 func TestLex_error(t *testing.T) {

--- a/parser/lexer/token.go
+++ b/parser/lexer/token.go
@@ -31,17 +31,13 @@ func (t Token) String() string {
 }
 
 func (t Token) Is(kind Kind, values ...string) bool {
-	if len(values) == 0 {
-		return kind == t.Kind
+	if kind != t.Kind {
+		return false
 	}
-
 	for _, v := range values {
 		if v == t.Value {
-			goto found
+			return true
 		}
 	}
-	return false
-
-found:
-	return kind == t.Kind
+	return len(values) == 0
 }

--- a/parser/lexer/utils.go
+++ b/parser/lexer/utils.go
@@ -36,7 +36,8 @@ func unescape(value string) (string, error) {
 	if size >= math.MaxInt {
 		return "", fmt.Errorf("too large string")
 	}
-	buf := make([]byte, 0, size)
+	buf := new(strings.Builder)
+	buf.Grow(int(size))
 	for len(value) > 0 {
 		c, multibyte, rest, err := unescapeChar(value)
 		if err != nil {
@@ -44,13 +45,13 @@ func unescape(value string) (string, error) {
 		}
 		value = rest
 		if c < utf8.RuneSelf || !multibyte {
-			buf = append(buf, byte(c))
+			buf.WriteByte(byte(c))
 		} else {
 			n := utf8.EncodeRune(runeTmp[:], c)
-			buf = append(buf, runeTmp[:n]...)
+			buf.Write(runeTmp[:n])
 		}
 	}
-	return string(buf), nil
+	return buf.String(), nil
 }
 
 // unescapeChar takes a string input and returns the following info:

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/expr-lang/expr/file"
 	"github.com/expr-lang/expr/internal/testify/require"
 
 	"github.com/expr-lang/expr"
@@ -609,10 +610,10 @@ func TestVM_DirectCallOpcodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			program := vm.NewProgram(
-				nil, // source
-				nil, // node
-				nil, // locations
-				0,   // variables
+				file.Source{}, // source
+				nil,           // node
+				nil,           // locations
+				0,             // variables
 				tt.consts,
 				tt.bytecode,
 				tt.args,
@@ -735,10 +736,10 @@ func TestVM_IndexAndCountOperations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			program := vm.NewProgram(
-				nil, // source
-				nil, // node
-				nil, // locations
-				0,   // variables
+				file.Source{}, // source
+				nil,           // node
+				nil,           // locations
+				0,             // variables
 				tt.consts,
 				tt.bytecode,
 				tt.args,
@@ -1176,10 +1177,10 @@ func TestVM_DirectBasicOpcodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			program := vm.NewProgram(
-				nil, // source
-				nil, // node
-				nil, // locations
-				0,   // variables
+				file.Source{}, // source
+				nil,           // node
+				nil,           // locations
+				0,             // variables
 				tt.consts,
 				tt.bytecode,
 				tt.args,


### PR DESCRIPTION
Fixes #810 

Benchmark results (20% faster, 40% less memory copying, 75% less allocations):
```
goos: darwin
goarch: arm64
pkg: github.com/expr-lang/expr/parser/lexer
cpu: Apple M4 Pro
          │   old.txt   │               new.txt               │
          │   sec/op    │   sec/op     vs base                │
Parser-12   1.549µ ± 1%   1.254µ ± 1%  -19.05% (p=0.000 n=20)

          │   old.txt    │               new.txt                │
          │     B/op     │     B/op      vs base                │
Parser-12   2.961Ki ± 0%   1.789Ki ± 0%  -39.58% (p=0.000 n=20)

          │   old.txt   │              new.txt               │
          │  allocs/op  │ allocs/op   vs base                │
Parser-12   27.000 ± 0%   7.000 ± 0%  -74.07% (p=0.000 n=20)
```

Benchmarks were performed in the `parser/lexer` directory executing the command:
```
go test -run=zzz-no-tests -bench=. -count=20 > file
```
The file was renamed to either `old.txt` or `new.txt`, and the comparison was made with:
```
benchstat old.txt new.txt
```

<details><summary>Raw results from old.txt</summary>
<p>

```
goos: darwin
goarch: arm64
pkg: github.com/expr-lang/expr/parser/lexer
cpu: Apple M4 Pro
BenchmarkParser-12        790826              1559 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        727635              1547 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        657169              1522 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        670780              1572 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        739662              1558 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        763692              1560 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        749037              1550 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        761952              1526 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        791458              1524 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        757533              1533 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        762931              1606 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        752461              1593 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        727683              1545 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        775984              1534 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        771271              1534 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        783654              1582 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        774580              1547 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        754653              1539 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        758157              1568 ns/op            3032 B/op         27 allocs/op
BenchmarkParser-12        754888              1551 ns/op            3032 B/op         27 allocs/op
PASS
ok      github.com/expr-lang/expr/parser/lexer  24.998s
```

</p>
</details> 

<details><summary>Raw results from new.txt</summary>
<p>

```
goos: darwin
goarch: arm64
pkg: github.com/expr-lang/expr/parser/lexer
cpu: Apple M4 Pro
BenchmarkParser-12        883687              1250 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        926926              1229 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        965379              1227 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        961345              1251 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        902880              1332 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        880496              1368 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        958262              1236 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        933210              1241 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        941917              1271 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        886873              1263 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        927643              1251 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        960315              1257 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        944788              1263 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        904806              1267 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        938611              1243 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        947118              1256 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        946309              1251 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        948300              1293 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        909182              1260 ns/op            1832 B/op          7 allocs/op
BenchmarkParser-12        933751              1251 ns/op            1832 B/op          7 allocs/op
PASS
ok      github.com/expr-lang/expr/parser/lexer  25.899s
```

</p>
</details> 