### PR TITLE
Fix *vm.VM memory leak

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -67,9 +67,11 @@ func (vm *VM) Run(program *Program, env any) (_ any, err error) {
 	if vm.Stack == nil {
 		vm.Stack = make([]any, 0, 2)
 	} else {
+		clearSlice(vm.Stack)
 		vm.Stack = vm.Stack[0:0]
 	}
 	if vm.Scopes != nil {
+		clearSlice(vm.Scopes)
 		vm.Scopes = vm.Scopes[0:0]
 	}
 	if len(vm.Variables) < program.variables {
@@ -613,4 +615,11 @@ func (vm *VM) Step() {
 
 func (vm *VM) Position() chan int {
 	return vm.curr
+}
+
+func clearSlice[S ~[]E, E any](s S) {
+	var zero E
+	for i := range s {
+		s[i] = zero // clear mem, optimized by the compiler, in Go 1.21 the "clear" builtin can be used
+	}
 }


### PR DESCRIPTION
Currently, it's reslicing using `[0:0]` (which is equivalent to `[:0]`), but this does not clear the memory references in the underlying array, which prevents garbage collection. For instance, if:

- A VM runs a program and pushes N items to the stack
- The last item is (or contains) a pointer or reference type
- The VM is later reused, but it always pushes less than N items to the stack

Then the Nth old item will not be garbage collected because there is still a reference to it in the underlying array.

So we need to "clear the tail" of the slice before reslicing to avoid this. See these example issues:

- https://go.dev/blog/slices-intro#a-possible-gotcha
- https://go.dev/blog/generic-slice-functions#the-fix