### PR TITLE
Fix error position reporting in multiline script

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -1757,6 +1757,17 @@ func TestEval_exposed_error(t *testing.T) {
 	require.Equal(t, 1, fileError.Line)
 }
 
+func TestCompile_exposed_error_with_multiline_script(t *testing.T) {
+	_, err := expr.Compile("{\n\ta: 1,\n\tb: #,\n\tc: 3,\n}")
+	require.Error(t, err)
+
+	fileError, ok := err.(*file.Error)
+	require.True(t, ok, "error should be of type *file.Error")
+	require.Equal(t, "unexpected token Operator(\"#\") (3:5)\n |  b: #,\n | ....^", fileError.Error())
+	require.Equal(t, 4, fileError.Column)
+	require.Equal(t, 3, fileError.Line)
+}
+
 func TestIssue105(t *testing.T) {
 	type A struct {
 		Field string

--- a/file/error.go
+++ b/file/error.go
@@ -31,12 +31,13 @@ func (e *Error) Bind(source Source) *Error {
 			break
 		}
 		if r == '\n' {
-			lineStart = i
+			lineStart = i + 1
 			e.Line++
 			e.Column = 0
+		} else {
+			e.Column++
 		}
 		runeCount++
-		e.Column++
 	}
 
 	lineEnd := lineStart + strings.IndexByte(src[lineStart:], '\n')


### PR DESCRIPTION
Fixes issue #826

Description of changes:
The problem was that lineStart was set not after the '\n' character, but directly on it, which caused lineStart to always equal lineEnd.
In addition, there was a second minor issue — the '\n' character was being counted in the column counter, which made the counter always show 1 more than it should.