### PR TITLE
Add support for custom struct tags via environment variable

### DIFF
--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"fmt"
+	"github.com/expr-lang/expr/environment"
 	"math"
 	"reflect"
 	"strconv"
@@ -421,7 +422,7 @@ func get(params ...any) (out any, err error) {
 		fieldName := i.(string)
 		value := v.FieldByNameFunc(func(name string) bool {
 			field, _ := v.Type().FieldByName(name)
-			switch field.Tag.Get("expr") {
+			switch field.Tag.Get(environment.GetGoTag()) {
 			case "-":
 				return false
 			case fieldName:

--- a/checker/nature/utils.go
+++ b/checker/nature/utils.go
@@ -1,13 +1,14 @@
 package nature
 
 import (
+	"github.com/expr-lang/expr/environment"
 	"reflect"
 
 	"github.com/expr-lang/expr/internal/deref"
 )
 
 func fieldName(field reflect.StructField) (string, bool) {
-	switch taggedName := field.Tag.Get("expr"); taggedName {
+	switch taggedName := field.Tag.Get(environment.GetGoTag()); taggedName {
 	case "-":
 		return "", false
 	case "":

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -1,0 +1,16 @@
+package environment
+
+import "os"
+
+const (
+	ExprEnvGotag = "expr__gotag"
+	DefaultGotag = "expr"
+)
+
+func GetGoTag() string {
+	if v := os.Getenv(ExprEnvGotag); v != "" {
+		return v
+	} else {
+		return DefaultGotag
+	}
+}

--- a/vm/runtime/runtime.go
+++ b/vm/runtime/runtime.go
@@ -4,6 +4,7 @@ package runtime
 
 import (
 	"fmt"
+	"github.com/expr-lang/expr/environment"
 	"math"
 	"reflect"
 
@@ -65,7 +66,7 @@ func Fetch(from, i any) any {
 		fieldName := i.(string)
 		value := v.FieldByNameFunc(func(name string) bool {
 			field, _ := v.Type().FieldByName(name)
-			switch field.Tag.Get("expr") {
+			switch field.Tag.Get(environment.GetGoTag()) {
 			case "-":
 				return false
 			case fieldName:
@@ -223,7 +224,7 @@ func In(needle any, array any) bool {
 			panic(fmt.Sprintf("cannot use %T as field name of %T", needle, array))
 		}
 		field, ok := v.Type().FieldByName(n.String())
-		if !ok || !field.IsExported() || field.Tag.Get("expr") == "-" {
+		if !ok || !field.IsExported() || field.Tag.Get(environment.GetGoTag()) == "-" {
 			return false
 		}
 		value := v.FieldByIndex(field.Index)


### PR DESCRIPTION
Fix: https://github.com/expr-lang/expr/issues/234

Add support for custom struct tags via environment variable, set gotags to read by **system env variables.**

To easily reference field by custom go tags like `json`, `mapstructre`, which is especially useful when dealing with generated go structs like protobuf.