### PR TITLE
fix(builtin): guard against missing args in builtins

### DIFF
--- a/builtin/builtin.go
+++ b/builtin/builtin.go
@@ -222,6 +222,9 @@ var Builtins = []*Function{
 	{
 		Name: "trimPrefix",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
+			}
 			s := " "
 			if len(args) == 2 {
 				s = args[1].(string)
@@ -236,6 +239,9 @@ var Builtins = []*Function{
 	{
 		Name: "trimSuffix",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
+			}
 			s := " "
 			if len(args) == 2 {
 				s = args[1].(string)
@@ -312,6 +318,9 @@ var Builtins = []*Function{
 	{
 		Name: "repeat",
 		Safe: func(args ...any) (any, uint, error) {
+			if len(args) < 2 {
+				return nil, 0, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(args))
+			}
 			s := args[0].(string)
 			n := runtime.ToInt(args[1])
 			if n < 0 {
@@ -327,6 +336,9 @@ var Builtins = []*Function{
 	{
 		Name: "join",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
+			}
 			glue := ""
 			if len(args) == 2 {
 				glue = args[1].(string)
@@ -354,6 +366,9 @@ var Builtins = []*Function{
 	{
 		Name: "indexOf",
 		Func: func(args ...any) (any, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(args))
+			}
 			return strings.Index(args[0].(string), args[1].(string)), nil
 		},
 		Types: types(strings.Index),
@@ -361,6 +376,9 @@ var Builtins = []*Function{
 	{
 		Name: "lastIndexOf",
 		Func: func(args ...any) (any, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(args))
+			}
 			return strings.LastIndex(args[0].(string), args[1].(string)), nil
 		},
 		Types: types(strings.LastIndex),
@@ -368,6 +386,9 @@ var Builtins = []*Function{
 	{
 		Name: "hasPrefix",
 		Func: func(args ...any) (any, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(args))
+			}
 			return strings.HasPrefix(args[0].(string), args[1].(string)), nil
 		},
 		Types: types(strings.HasPrefix),
@@ -375,6 +396,9 @@ var Builtins = []*Function{
 	{
 		Name: "hasSuffix",
 		Func: func(args ...any) (any, error) {
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 2, got %d)", len(args))
+			}
 			return strings.HasSuffix(args[0].(string), args[1].(string)), nil
 		},
 		Types: types(strings.HasSuffix),
@@ -436,6 +460,9 @@ var Builtins = []*Function{
 	{
 		Name: "toJSON",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			b, err := json.MarshalIndent(args[0], "", "  ")
 			if err != nil {
 				return nil, err
@@ -447,6 +474,9 @@ var Builtins = []*Function{
 	{
 		Name: "fromJSON",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			var v any
 			err := json.Unmarshal([]byte(args[0].(string)), &v)
 			if err != nil {
@@ -459,6 +489,9 @@ var Builtins = []*Function{
 	{
 		Name: "toBase64",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			return base64.StdEncoding.EncodeToString([]byte(args[0].(string))), nil
 		},
 		Types: types(new(func(string) string)),
@@ -466,6 +499,9 @@ var Builtins = []*Function{
 	{
 		Name: "fromBase64",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			b, err := base64.StdEncoding.DecodeString(args[0].(string))
 			if err != nil {
 				return nil, err
@@ -505,6 +541,9 @@ var Builtins = []*Function{
 	{
 		Name: "duration",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			return time.ParseDuration(args[0].(string))
 		},
 		Types: types(time.ParseDuration),
@@ -512,9 +551,15 @@ var Builtins = []*Function{
 	{
 		Name: "date",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
+			}
 			tz, ok := args[0].(*time.Location)
 			if ok {
 				args = args[1:]
+			}
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected at least 1, got 0)")
 			}
 
 			date := args[0].(string)
@@ -585,6 +630,9 @@ var Builtins = []*Function{
 	{
 		Name: "timezone",
 		Func: func(args ...any) (any, error) {
+			if len(args) == 0 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got 0)")
+			}
 			tz, err := time.LoadLocation(args[0].(string))
 			if err != nil {
 				return nil, err
@@ -596,6 +644,9 @@ var Builtins = []*Function{
 	{
 		Name: "first",
 		Func: func(args ...any) (any, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got %d)", len(args))
+			}
 			defer func() {
 				if r := recover(); r != nil {
 					return
@@ -619,6 +670,9 @@ var Builtins = []*Function{
 	{
 		Name: "last",
 		Func: func(args ...any) (any, error) {
+			if len(args) != 1 {
+				return nil, fmt.Errorf("invalid number of arguments (expected 1, got %d)", len(args))
+			}
 			defer func() {
 				if r := recover(); r != nil {
 					return

--- a/testdata/generated.txt
+++ b/testdata/generated.txt
@@ -763,7 +763,6 @@ $env not contains $env?.[Bar]?.add()
 $env not contains $env?.[Bar]?.ok
 $env not contains $env?.[String?.str]
 $env not contains $env?.[String]
-$env not contains $env?.[first(foobar, greet)]
 $env not contains $env?.[foobar?.array()]
 $env not contains $env?.[foobar]
 $env not contains $env?.[toJSON(foobar)]
@@ -3513,7 +3512,6 @@ $env?.[Bar]?.str(f64)
 $env?.[Bar]?.str(f64, array)
 $env?.[Bar]?.str(foobar)
 $env?.[Bar]?.str(greet)
-$env?.[Bar]?.str(list | first(true, foobar))
 $env?.[Bar]?.str(list)
 $env?.[Bar]?.str(nil)
 $env?.[Bar]?.str.Bar
@@ -3645,7 +3643,6 @@ $env?.[String]?.String(foobar)
 $env?.[String]?.String(foobar, $env)
 $env?.[String]?.String(foobar?.[list])?.str()
 $env?.[String]?.String(greet)
-$env?.[String]?.String(last($env, String))
 $env?.[String]?.String(ok && foobar)
 $env?.[String]?.String.add
 $env?.[String]?.String.split(false, add).str.array
@@ -6984,7 +6981,6 @@ $env[:str] not in foo || true
 0 == $env?.[Bar | get(foo)]
 0 == $env?.[Bar]
 0 == $env?.[String]
-0 == $env?.[first(0, ok)]
 0 == $env?.[foobar]
 0 == $env?.[foobar]?.add
 0 == $env?.[str]
@@ -18596,7 +18592,6 @@ foo not in $env?.[foobar?.f64]
 foo not in $env?.[foobar?.foo]
 foo not in $env?.[foobar]
 foo not in $env?.[foobar]?.[greet]
-foo not in $env?.[nil | last(foobar)]
 foo not in $env?.[nil]
 foo not in $env?.foobar
 foo not in $env?.foobar?.greet(foobar)
@@ -28092,7 +28087,6 @@ nil != $env?.Bar?.list()
 nil != $env?.Bar?.str()
 nil != $env?.String
 nil != $env?.String?.[i]
-nil != $env?.[1.0 | first(nil)]
 nil != $env?.[Bar]
 nil != $env?.[Bar]?.Bar
 nil != $env?.[String]
@@ -36587,7 +36581,6 @@ true in $env?.String
 true in $env?.[Bar]
 true in $env?.[String]
 true in $env?.[first(foobar)]
-true in $env?.[foobar | last(nil)]
 true in $env?.[foobar]
 true not in $env?.Bar
 true not in $env?.String


### PR DESCRIPTION
## Motivation

Relates to #941.

OSS-Fuzz finding has a fuzzed expression which calls `join()` with zero arguments inside a method call on an any-typed value (e.g. `fn().N(join())`). The type checker's `callNode()` skips argument validation when the callee resolves to an unknown type, so the invalid call passes compilation. At runtime `join()` accesses `args[0]` on an empty slice, producing a Go runtime panic instead of a clean error.

I found similar issues from other builtins, relying solely on compile-time validation that can be bypassed.

## Changes

Add runtime `len(args)` guards to a number of builtin functions. Each now returns a descriptive error. This error is already part of the allowlist in the fuzzing harness.

I also removed some autogenerated test lines that called `first` and `last` with wrong arity. These tests were passing because of `defer recover()` silently swallowing the panic.

## Further comments

I think there is a chance to fix this in the checker, to provide compile-time rejection. But I guess it'll be quite complicated because of optional chaining on unknown types for a number of different expressions. This fix is the conservative kind just to have clean and descriptive runtime errors.