### PR TITLE
guard map key type before MapIndex in get

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -300,6 +300,29 @@ func TestBuiltin_errors(t *testing.T) {
 	}
 }
 
+func TestGet_mapKeyTypeMismatch(t *testing.T) {
+	env := map[string]any{
+		"strMap": map[string]any{"a": 1},
+		"intMap": map[int]any{1: "x"},
+		"anyMap": map[any]any{"a": 1},
+	}
+	tests := []string{
+		`get(strMap, 5)`,   // int key into map[string]any
+		`get(strMap, [1])`, // slice key into map[string]any
+		`get(intMap, "s")`, // string key into map[int]any
+		`get(anyMap, [1])`, // non-comparable key into map[any]any
+	}
+	for _, code := range tests {
+		t.Run(code, func(t *testing.T) {
+			program, err := expr.Compile(code, expr.AllowUndefinedVariables())
+			require.NoError(t, err)
+			out, err := expr.Run(program, env)
+			require.NoError(t, err)
+			assert.Nil(t, out)
+		})
+	}
+}
+
 func TestBuiltin_env_not_callable(t *testing.T) {
 	code := `$env(''matches'i'?t:get().UTC())`
 	env := map[string]any{"t": 1}
@@ -874,10 +897,10 @@ func TestAbs_UnsignedIntegers(t *testing.T) {
 	// Test that abs() correctly handles unsigned integers
 	// Unsigned integers are always non-negative, so abs() should return them unchanged
 	tests := []struct {
-		name  string
-		env   map[string]any
-		expr  string
-		want  any
+		name string
+		env  map[string]any
+		expr string
+		want any
 	}{
 		{"uint", map[string]any{"x": uint(42)}, "abs(x)", uint(42)},
 		{"uint8", map[string]any{"x": uint8(42)}, "abs(x)", uint8(42)},

--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -588,7 +588,11 @@ func get(params ...any) (out any, err error) {
 		if i == nil {
 			value = v.MapIndex(reflect.Zero(v.Type().Key()))
 		} else {
-			value = v.MapIndex(reflect.ValueOf(i))
+			key := reflect.ValueOf(i)
+			if !key.Type().AssignableTo(v.Type().Key()) || !key.Type().Comparable() {
+				return nil, nil
+			}
+			value = v.MapIndex(key)
 		}
 		if value.IsValid() {
 			return value.Interface(), nil


### PR DESCRIPTION
The get builtin documents that it returns nil instead of panicking, but the map branch calls v.MapIndex(reflect.ValueOf(i)) directly. When the key is not assignable to the map's key type, or is an unhashable value reaching a map[any]any, reflect panics and the vm surfaces a raw reflect message like "reflect.Value.MapIndex: value of type ... is not assignable". Reachable from a dynamically typed map, e.g. get(m, [1,2]) where m has static type any. Check the key against the map key type and comparability first and fall back to nil, matching how missing keys already behave.