### PR TITLE
return error for non-comparable key in get builtin

### DIFF
--- a/builtin/builtin_test.go
+++ b/builtin/builtin_test.go
@@ -271,6 +271,7 @@ func TestBuiltin_errors(t *testing.T) {
 		{`date("error")`, `invalid date`},
 		{`get()`, `invalid number of arguments (expected 2, got 0)`},
 		{`get(1, 2)`, `type int does not support indexing`},
+		{`get(groupBy([1, 2, 3], # % 2), [1])`, `cannot use []interface {} as a map key: type is not comparable`},
 		{`bitnot("1")`, "cannot use string as argument (type int) to call bitnot  (1:8)"},
 		{`bitand("1", 1)`, "cannot use string as argument (type int) to call bitand  (1:8)"},
 		{`"10" | bitor(1)`, "cannot use string as argument (type int) to call bitor  (1:1)"},

--- a/builtin/lib.go
+++ b/builtin/lib.go
@@ -588,7 +588,11 @@ func get(params ...any) (out any, err error) {
 		if i == nil {
 			value = v.MapIndex(reflect.Zero(v.Type().Key()))
 		} else {
-			value = v.MapIndex(reflect.ValueOf(i))
+			key := reflect.ValueOf(i)
+			if !key.Type().Comparable() {
+				return nil, fmt.Errorf("cannot use %s as a map key: type is not comparable", key.Type())
+			}
+			value = v.MapIndex(key)
 		}
 		if value.IsValid() {
 			return value.Interface(), nil

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -66,6 +66,7 @@ func FuzzExpr(f *testing.F) {
 		regexp.MustCompile(`invalid order .*, expected asc or desc`),
 		regexp.MustCompile(`unknown order, use asc or desc`),
 		regexp.MustCompile(`cannot use .* as a key for groupBy: type is not comparable`),
+		regexp.MustCompile(`cannot use .* as a map key: type is not comparable`),
 	}
 
 	env := NewEnv()


### PR DESCRIPTION
Noticed get indexes a map with reflect.Value.MapIndex(reflect.ValueOf(i)) but never checks the key is comparable. When the map key type is dynamic, e.g. groupBy returns map[any][]any, a slice key passes the checker and hits a raw "hash of unhashable type" panic at runtime, so get(groupBy([1,2,3], # % 2), [1]) blows up. Since get returns errors directly, return a clean "not comparable" error before the lookup, same as the groupBy fix.