### PR TITLE
Match float literals to float32 comparisons

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -112,8 +112,8 @@ type BytesNode struct {
 
 // ConstantNode represents a constant.
 // Constants are predefined values like nil, true, false, array, map, etc.
-// The parser.Parse will never generate ConstantNode, it is only generated
-// by the optimizer.
+// The parser.Parse will never generate ConstantNode; it is generated after
+// parsing by optimizers and patchers.
 type ConstantNode struct {
 	base
 	Value any // Value of the constant.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -78,7 +78,13 @@ func (v *Checker) PatchAndCheck(tree *parser.Tree, config *conf.Config) (reflect
 		// Run patchers that require multiple passes next (currently only Operator patching)
 		v.runVisitors(tree, true)
 	}
-	return v.Check(tree, config)
+
+	typ, err := v.Check(tree, config)
+	if err != nil {
+		return typ, err
+	}
+	ast.Walk(&tree.Node, float32ComparisonLiterals{})
+	return typ, nil
 }
 
 // Check checks types of the expression tree. It returns type of the expression

--- a/checker/float32.go
+++ b/checker/float32.go
@@ -1,0 +1,57 @@
+package checker
+
+import (
+	"reflect"
+
+	"github.com/expr-lang/expr/ast"
+)
+
+var float32Type = reflect.TypeOf(float32(0))
+
+type float32ComparisonLiterals struct{}
+
+func (float32ComparisonLiterals) Visit(node *ast.Node) {
+	binary, ok := (*node).(*ast.BinaryNode)
+	if !ok || !isComparisonOperator(binary.Operator) {
+		return
+	}
+
+	patchFloat32Literal(&binary.Right, binary.Left.Type())
+	patchFloat32Literal(&binary.Left, binary.Right.Type())
+}
+
+func patchFloat32Literal(node *ast.Node, target reflect.Type) {
+	if target != float32Type {
+		return
+	}
+
+	switch literal := (*node).(type) {
+	case *ast.FloatNode:
+		ast.Patch(node, newFloat32Constant(float32(literal.Value)))
+	case *ast.UnaryNode:
+		if literal.Operator == "+" || literal.Operator == "-" {
+			if value, ok := literal.Node.(*ast.FloatNode); ok {
+				floatValue := float32(value.Value)
+				if literal.Operator == "-" {
+					floatValue = -floatValue
+				}
+				ast.Patch(node, newFloat32Constant(floatValue))
+			}
+		}
+	}
+}
+
+func newFloat32Constant(value float32) *ast.ConstantNode {
+	node := &ast.ConstantNode{Value: value}
+	node.SetType(float32Type)
+	return node
+}
+
+func isComparisonOperator(operator string) bool {
+	switch operator {
+	case "==", "!=", "<", ">", "<=", ">=":
+		return true
+	default:
+		return false
+	}
+}

--- a/float32_test.go
+++ b/float32_test.go
@@ -1,0 +1,45 @@
+package expr_test
+
+import (
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/internal/testify/assert"
+	"github.com/expr-lang/expr/internal/testify/require"
+)
+
+func TestFloat32LiteralComparisons(t *testing.T) {
+	env := struct {
+		Positive float32
+		Negative float32
+		Float64  float64
+	}{
+		Positive: 12.34,
+		Negative: -12.34,
+		Float64:  12.34,
+	}
+	tests := []struct {
+		code string
+		want bool
+	}{
+		{"Positive == 12.34", true},
+		{"12.34 == Positive", true},
+		{"Negative == -12.34", true},
+		{"Positive <= 12.34", true},
+		{"Positive != 12.34", false},
+		{"Float64 == 12.34", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.code, func(t *testing.T) {
+			for _, optimize := range []bool{true, false} {
+				program, err := expr.Compile(test.code, expr.Env(env), expr.Optimize(optimize))
+				require.NoError(t, err)
+
+				output, err := expr.Run(program, env)
+				require.NoError(t, err)
+				assert.Equal(t, test.want, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #609

## Root cause

Expr compiles floating-point literals as `float64`. Comparing one directly with a `float32` operand therefore compares the rounded `float32` value with the original `float64` literal, unlike Go's conversion of the untyped literal to `float32`.

## Fix

After type checking, patch float literals used directly in comparisons with `float32` operands into typed `float32` constants. This handles either operand order and signed literals without changing mixed `float32`/`float64` arithmetic.

## Tests

- `go test .\checker . -run 'Test(Float32LiteralComparisons|Check)' -count=1`
- `go test ./...`
- `go test -tags=expr_debug -run=TestDebugger -v ./vm`
- `go vet ./...`

The regression test covers optimized and unoptimized compilation, both operand orders, signed literals, relational and inequality comparisons, and verifies `float64` behavior remains unchanged.

`go test -race .` was not available on this Windows host because the installed Go toolchain has CGO disabled.